### PR TITLE
Add support for rolling evaluation in TaskGenerator

### DIFF
--- a/docs/03-tasks-and-benchmarks.ipynb
+++ b/docs/03-tasks-and-benchmarks.ipynb
@@ -142,7 +142,7 @@
     "    horizon=24,\n",
     "    target_column=\"OT\",\n",
     ")\n",
-    "past_data, future_data = task.get_input_data()\n",
+    "past_data, future_data = task.get_input_data(trust_remote_code=True)\n",
     "print(past_data)\n",
     "print(future_data)"
    ]
@@ -425,7 +425,7 @@
     "        {\"cutoff\": \"2017-01-01\"},\n",
     "        {\"cutoff\": \"2017-02-07\"},\n",
     "        {\"cutoff\": \"2017-06-03\"},\n",
-    "    ]\n",
+    "    ],\n",
     ")\n",
     "tasks = task_generator.generate_tasks()\n",
     "for i, task in enumerate(tasks):\n",
@@ -500,7 +500,83 @@
     "    variants=[\n",
     "        {\"horizon\": 12},\n",
     "        {\"horizon\": 24},\n",
-    "    ]\n",
+    "    ],\n",
+    ")\n",
+    "task_generator.generate_tasks()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, we can use the keywords `num_rolling_windows`, `initial_cutoff` and `rolling_step_size` to create multiple rolling evaluation tasks from a single `TaskGenerator`.\n",
+    "\n",
+    "We can use integer-based cutoffs:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Task(dataset_path='my_dataset', dataset_config='my_config', horizon=24, cutoff=-96, lead_time=1, min_ts_length=25, max_context_length=None, seasonality=1, eval_metric='MASE', extra_metrics=[], quantile_levels=None, id_column='id', timestamp_column='timestamp', target_column='target', multiple_target_columns=None, past_dynamic_columns=[], excluded_columns=[]),\n",
+       " Task(dataset_path='my_dataset', dataset_config='my_config', horizon=24, cutoff=-72, lead_time=1, min_ts_length=25, max_context_length=None, seasonality=1, eval_metric='MASE', extra_metrics=[], quantile_levels=None, id_column='id', timestamp_column='timestamp', target_column='target', multiple_target_columns=None, past_dynamic_columns=[], excluded_columns=[]),\n",
+       " Task(dataset_path='my_dataset', dataset_config='my_config', horizon=24, cutoff=-48, lead_time=1, min_ts_length=25, max_context_length=None, seasonality=1, eval_metric='MASE', extra_metrics=[], quantile_levels=None, id_column='id', timestamp_column='timestamp', target_column='target', multiple_target_columns=None, past_dynamic_columns=[], excluded_columns=[])]"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "task_generator = fev.TaskGenerator(\n",
+    "    dataset_path=\"my_dataset\",\n",
+    "    dataset_config=\"my_config\",\n",
+    "    horizon=24,\n",
+    "    num_rolling_windows=3,\n",
+    "    initial_cutoff=-96,\n",
+    "    rolling_step_size=None,  # defaults to `horizon`\n",
+    ")\n",
+    "task_generator.generate_tasks()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or timestamp-based cutoffs:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Task(dataset_path='my_dataset', dataset_config='my_config', horizon=24, cutoff='2024-01-04T00:00:00', lead_time=1, min_ts_length=25, max_context_length=None, seasonality=1, eval_metric='MASE', extra_metrics=[], quantile_levels=None, id_column='id', timestamp_column='timestamp', target_column='target', multiple_target_columns=None, past_dynamic_columns=[], excluded_columns=[]),\n",
+       " Task(dataset_path='my_dataset', dataset_config='my_config', horizon=24, cutoff='2024-01-04T12:00:00', lead_time=1, min_ts_length=25, max_context_length=None, seasonality=1, eval_metric='MASE', extra_metrics=[], quantile_levels=None, id_column='id', timestamp_column='timestamp', target_column='target', multiple_target_columns=None, past_dynamic_columns=[], excluded_columns=[]),\n",
+       " Task(dataset_path='my_dataset', dataset_config='my_config', horizon=24, cutoff='2024-01-05T00:00:00', lead_time=1, min_ts_length=25, max_context_length=None, seasonality=1, eval_metric='MASE', extra_metrics=[], quantile_levels=None, id_column='id', timestamp_column='timestamp', target_column='target', multiple_target_columns=None, past_dynamic_columns=[], excluded_columns=[])]"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "task_generator = fev.TaskGenerator(\n",
+    "    dataset_path=\"my_dataset\",\n",
+    "    dataset_config=\"my_config\",\n",
+    "    horizon=24,\n",
+    "    num_rolling_windows=3,\n",
+    "    initial_cutoff=\"2024-01-04\",\n",
+    "    rolling_step_size=\"12h\",  # required if `initial_cutoff` is a string\n",
     ")\n",
     "task_generator.generate_tasks()"
    ]
@@ -517,7 +593,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,7 +614,7 @@
     "        \"variants\": [\n",
     "            {\"cutoff\": \"2013-01-01\"},\n",
     "            {\"cutoff\": \"2014-01-01\"},\n",
-    "        ]\n",
+    "        ],\n",
     "    },\n",
     "]\n",
     "benchmark = fev.Benchmark.from_list(task_generators)"
@@ -553,7 +629,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -582,7 +658,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -591,7 +667,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -602,7 +678,7 @@
        " Task(dataset_path='autogluon/chronos_datasets', dataset_config='monash_electricity_weekly', horizon=8, cutoff='2014-01-01T00:00:00', lead_time=1, min_ts_length=9, max_context_length=None, seasonality=1, eval_metric='MASE', extra_metrics=[], quantile_levels=None, id_column='id', timestamp_column='timestamp', target_column='target', multiple_target_columns=None, past_dynamic_columns=[], excluded_columns=[])]"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -620,7 +696,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -637,7 +713,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -657,40 +733,24 @@
     "\n",
     "    predictions = []\n",
     "    for ts in past_data:\n",
-    "        predictions.append(\n",
-    "            {\"predictions\": model.forecast(y=ts[task.target_column], h=task.horizon)[\"mean\"]}\n",
-    "        )\n",
+    "        predictions.append({\"predictions\": model.forecast(y=ts[task.target_column], h=task.horizon)[\"mean\"]})\n",
     "    return predictions"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fa89e5d2ec8d4c8f8c83aa348d47218d",
+       "model_id": "6168552cfcef4d99a0d2d6fd3084a1d4",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
        "Tasks completed:   0%|          | 0/3 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8ef224484a4c4aab82cf3138f8048471",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "train-00000-of-00001.parquet:   0%|          | 0.00/334k [00:00<?, ?B/s]"
       ]
      },
      "metadata": {},
@@ -706,14 +766,16 @@
     "        start_time = time.time()\n",
     "        predictions = predict_with_model(task, model_name=model_name)\n",
     "        infer_time_s = time.time() - start_time\n",
-    "        eval_summary = task.evaluation_summary(predictions, model_name=model_name, inference_time_s=infer_time_s, training_time_s=0.0)\n",
+    "        eval_summary = task.evaluation_summary(\n",
+    "            predictions, model_name=model_name, inference_time_s=infer_time_s, training_time_s=0.0\n",
+    "        )\n",
     "\n",
     "        summaries.append(eval_summary)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -763,8 +825,8 @@
        "      <th>theta</th>\n",
        "      <td>0.914107</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>9.312378</td>\n",
-       "      <td>2.221101</td>\n",
+       "      <td>9.158595</td>\n",
+       "      <td>1.283440</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
@@ -774,8 +836,8 @@
        "      <th>seasonal_naive</th>\n",
        "      <td>1.000000</td>\n",
        "      <td>2.0</td>\n",
-       "      <td>3.534666</td>\n",
-       "      <td>4.066241</td>\n",
+       "      <td>2.867543</td>\n",
+       "      <td>2.837273</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
@@ -785,8 +847,8 @@
        "      <th>arima</th>\n",
        "      <td>1.870027</td>\n",
        "      <td>3.0</td>\n",
-       "      <td>0.637881</td>\n",
-       "      <td>0.692875</td>\n",
+       "      <td>0.381187</td>\n",
+       "      <td>0.415345</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
@@ -799,15 +861,15 @@
       "text/plain": [
        "                gmean_relative_error  avg_rank  avg_inference_time_s  \\\n",
        "model_name                                                             \n",
-       "theta                       0.914107       1.0              9.312378   \n",
-       "seasonal_naive              1.000000       2.0              3.534666   \n",
-       "arima                       1.870027       3.0              0.637881   \n",
+       "theta                       0.914107       1.0              9.158595   \n",
+       "seasonal_naive              1.000000       2.0              2.867543   \n",
+       "arima                       1.870027       3.0              0.381187   \n",
        "\n",
        "                median_inference_time_s  avg_training_time_s  \\\n",
        "model_name                                                     \n",
-       "theta                          2.221101                  0.0   \n",
-       "seasonal_naive                 4.066241                  0.0   \n",
-       "arima                          0.692875                  0.0   \n",
+       "theta                          1.283440                  0.0   \n",
+       "seasonal_naive                 2.837273                  0.0   \n",
+       "arima                          0.415345                  0.0   \n",
        "\n",
        "                median_training_time_s  training_corpus_overlap  num_failures  \n",
        "model_name                                                                     \n",
@@ -816,7 +878,7 @@
        "arima                              0.0                      0.0             0  "
       ]
      },
-     "execution_count": 25,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -836,7 +898,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -900,7 +962,7 @@
        "chronos_datasets_monash_m1_yearly           4.988582  "
       ]
      },
-     "execution_count": 26,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1002,13 +1064,14 @@
        "chronos_datasets_monash_m1_yearly          -8                   4.988582  "
       ]
      },
-     "execution_count": 27,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "fev.pivot_table(summaries, task_columns=[\"dataset_name\", \"cutoff\"])  # you can filter any task properties such as `eval_metric`, `horizon`, etc"
+    "# you can filter any task properties such as `eval_metric`, `horizon`, etc\n",
+    "fev.pivot_table(summaries, task_columns=[\"dataset_name\", \"cutoff\"])"
    ]
   },
   {
@@ -1025,7 +1088,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -1073,10 +1136,10 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>auto_theta</th>\n",
-       "      <td>0.863439</td>\n",
-       "      <td>1.750000</td>\n",
-       "      <td>276.781533</td>\n",
-       "      <td>23.853687</td>\n",
+       "      <td>0.858722</td>\n",
+       "      <td>1.703704</td>\n",
+       "      <td>286.465526</td>\n",
+       "      <td>23.892088</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0</td>\n",
@@ -1084,10 +1147,10 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>auto_arima</th>\n",
-       "      <td>0.873645</td>\n",
-       "      <td>1.678571</td>\n",
-       "      <td>1615.091113</td>\n",
-       "      <td>65.344211</td>\n",
+       "      <td>0.869449</td>\n",
+       "      <td>1.703704</td>\n",
+       "      <td>1674.733082</td>\n",
+       "      <td>75.883700</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0</td>\n",
@@ -1096,9 +1159,9 @@
        "    <tr>\n",
        "      <th>seasonal_naive</th>\n",
        "      <td>1.000000</td>\n",
-       "      <td>2.571429</td>\n",
-       "      <td>2.327086</td>\n",
-       "      <td>0.091613</td>\n",
+       "      <td>2.592593</td>\n",
+       "      <td>2.415950</td>\n",
+       "      <td>0.096449</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0</td>\n",
@@ -1111,15 +1174,15 @@
       "text/plain": [
        "                gmean_relative_error  avg_rank  avg_inference_time_s  \\\n",
        "model_name                                                             \n",
-       "auto_theta                  0.863439  1.750000            276.781533   \n",
-       "auto_arima                  0.873645  1.678571           1615.091113   \n",
-       "seasonal_naive              1.000000  2.571429              2.327086   \n",
+       "auto_theta                  0.858722  1.703704            286.465526   \n",
+       "auto_arima                  0.869449  1.703704           1674.733082   \n",
+       "seasonal_naive              1.000000  2.592593              2.415950   \n",
        "\n",
        "                median_inference_time_s  avg_training_time_s  \\\n",
        "model_name                                                     \n",
-       "auto_theta                    23.853687                  NaN   \n",
-       "auto_arima                    65.344211                  NaN   \n",
-       "seasonal_naive                 0.091613                  NaN   \n",
+       "auto_theta                    23.892088                  NaN   \n",
+       "auto_arima                    75.883700                  NaN   \n",
+       "seasonal_naive                 0.096449                  NaN   \n",
        "\n",
        "                median_training_time_s  training_corpus_overlap  num_failures  \n",
        "model_name                                                                     \n",
@@ -1128,7 +1191,7 @@
        "seasonal_naive                     NaN                      0.0             0  "
       ]
      },
-     "execution_count": 31,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1144,7 +1207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -1307,12 +1370,6 @@
        "      <td>0.122691</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>monash_saugeenday</th>\n",
-       "      <td>0.413626</td>\n",
-       "      <td>0.479818</td>\n",
-       "      <td>0.422968</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th>monash_tourism_monthly</th>\n",
        "      <td>0.090934</td>\n",
        "      <td>0.090997</td>\n",
@@ -1376,7 +1433,6 @@
        "monash_m3_quarterly              0.076532    0.070173        0.101252\n",
        "monash_m3_yearly                 0.155759    0.127728        0.166533\n",
        "monash_nn5_weekly                0.084427    0.089608        0.122691\n",
-       "monash_saugeenday                0.413626    0.479818        0.422968\n",
        "monash_tourism_monthly           0.090934    0.090997        0.104182\n",
        "monash_tourism_quarterly         0.099659    0.061241        0.119375\n",
        "monash_tourism_yearly            0.128889    0.176017        0.209183\n",
@@ -1385,7 +1441,7 @@
        "nn5                              0.247710    0.293651        0.424621"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1411,7 +1467,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/src/fev/benchmark.py
+++ b/src/fev/benchmark.py
@@ -25,7 +25,7 @@ class Benchmark:
             elif isinstance(t, Task):
                 self.task_generators.append(TaskGenerator(**t.to_dict()))
             else:
-                raise ValueError(f"`tasks` must be a list of list of `Task` or `TaskGenerator` objects (got {type(t)})")
+                raise ValueError(f"`tasks` must be a list of `Task` or `TaskGenerator` objects (got {type(t)})")
 
     @classmethod
     def from_yaml(cls, file_path: str | Path) -> "Benchmark":


### PR DESCRIPTION
*Issue #, if available:* Fixes #5

*Description of changes:*
- `task.TaskGenerator`
  - Add new arguments `num_rolling_windows`, `initial_cutoff` and `rolling_step_size` to `TaskGenerator`. These arguments make it possible to compactly create multiple backtesting tasks from a single task.
- `benchmark.Benchmark`
  - Make it possible to create a Benchmark object from a list of TaskGenerators.
  - Expose the task_generators: list[TaskGenerator] attribute of the Benchmark (in addition to tasks: list[Task]).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
