### PR TITLE
Make dataset_fingerprint depend only on the dataset contents

### DIFF
--- a/src/fev/analysis.py
+++ b/src/fev/analysis.py
@@ -117,7 +117,7 @@ def leaderboard(
     included_models: list[str] | None = None,
     excluded_models: list[str] | None = None,
     benchmark: Benchmark | None = None,
-    validate_dataset_fingerprints: bool = True,
+    validate_dataset_fingerprints: bool = False,
 ):
     """Summarize benchmark results into a single table reporting aggregate performance of each model.
 
@@ -163,7 +163,7 @@ def leaderboard(
     benchmark : fev.Benchmark, optional
         If provided, the results will be computed using only the tasks included in the benchmark. If results for some
         tasks of this benchmark are missing, an exception will be raised.
-    validate_dataset_fingerprints : bool, default True
+    validate_dataset_fingerprints : bool, default False
         If `True`, this method will assert that the dataset fingerprint is unique for each task. This ensures that
         the same dataset version was used by all models.
     """


### PR DESCRIPTION
*Issue #, if available:* Fixes #7

*Description of changes:*
- Currently, `datasets.Dataset._dataset_fingerprint` property changes if, e.g., the README file was updated for the HF repository. This leads to changes in the `dataset_fingerprint` property stored by `fev` even if the underlying parquet/arrow files remain unchanged.
- This PR addresses this problem. Now the dataset_fingerprint depends only on the contents of the dataset. This is still not 100% waterproof as it only checks 1/ the string representation of the pyarrow.Table and 2/ its size in bytes. However, this looks like a reasonable sanity check that can catch most obvious changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
