### PR TITLE
Fix seasonal differences for short series

### DIFF
--- a/src/fev/__about__.py
+++ b/src/fev/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.0rc1"
+__version__ = "0.5.0rc2"

--- a/src/fev/metrics.py
+++ b/src/fev/metrics.py
@@ -271,7 +271,7 @@ class WQL(Metric):
 
 def _seasonal_diff(array: np.ndarray, seasonality: int) -> np.ndarray:
     if len(array) <= seasonality:
-        return []
+        return np.array([])
     else:
         return array[seasonality:] - array[:-seasonality]
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix NotImplementedError occurring when some historical series have fewer than `seasonality` observations


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
