### PR TITLE
Minor fixes and optimizations

### DIFF
--- a/src/fev/__about__.py
+++ b/src/fev/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.0rc1"
+__version__ = "0.6.0rc2"

--- a/src/fev/__init__.py
+++ b/src/fev/__init__.py
@@ -1,3 +1,4 @@
+from .__about__ import __version__
 from .adapters import convert_input_data
 from .analysis import leaderboard, pivot_table
 from .benchmark import Benchmark
@@ -5,6 +6,7 @@ from .task import Task, TaskGenerator
 from .utils import validate_time_series_dataset
 
 __all__ = [
+    "__version__",
     "Benchmark",
     "Task",
     "TaskGenerator",

--- a/src/fev/task.py
+++ b/src/fev/task.py
@@ -410,7 +410,7 @@ class Task(_TaskBase):
                 cutoff=self.cutoff,
                 min_context_length=self.min_context_length,
             ),
-            num_proc=num_proc,
+            num_proc=min(num_proc, len(dataset)),
             desc="Filtering short time series",
         )
         num_items_after = len(filtered_dataset)
@@ -442,7 +442,7 @@ class Task(_TaskBase):
                 cutoff=self.cutoff,
                 max_context_length=self.max_context_length,
             ),
-            num_proc=num_proc,
+            num_proc=min(num_proc, len(dataset)),
             desc="Selecting past data",
         )
 
@@ -454,7 +454,7 @@ class Task(_TaskBase):
                 cutoff=self.cutoff,
                 horizon=self.horizon,
             ),
-            num_proc=num_proc,
+            num_proc=min(num_proc, len(dataset)),
             desc="Selecting future data",
         )
         future_known = future_data.remove_columns(self.target_columns_list + self.past_dynamic_columns)

--- a/src/fev/utils.py
+++ b/src/fev/utils.py
@@ -95,7 +95,7 @@ def validate_time_series_dataset(
     for col in dynamic_columns:
         if not pc.list_value_length(table[col]) == expected_lengths:
             raise AssertionError(
-                f"Lengths of entries in {col} does not match the timestamp columns {timestamp_column} for all records"
+                f"Lengths of entries in {col} does not match the lengths in {timestamp_column} for all records"
             )
 
 

--- a/src/fev/utils.py
+++ b/src/fev/utils.py
@@ -50,6 +50,7 @@ def validate_time_series_dataset(
     timestamp_column
         Name of the column containing the timestamp of time series observations.
     """
+    dataset = dataset.with_format("numpy")
     if required_columns is None:
         required_columns = []
     required_columns += [id_column, timestamp_column]
@@ -80,7 +81,7 @@ def validate_time_series_dataset(
     if num_records_to_validate is not None:
         dataset = dataset.select(range(num_records_to_validate))
 
-    dataset.with_format("numpy").map(
+    dataset.map(
         _validate_frequency,
         num_proc=min(num_proc, len(dataset)),
         desc="Validating dataset format",

--- a/test/test_uitls.py
+++ b/test/test_uitls.py
@@ -1,4 +1,5 @@
 import datasets
+import pandas as pd
 import pytest
 
 import fev
@@ -18,3 +19,15 @@ def test_when_dataset_dict_provided_to_generate_fingerprint_then_exception_is_ra
     ds_dict = datasets.load_dataset("autogluon/chronos_datasets", "monash_m1_yearly")
     with pytest.raises(ValueError, match="datasets.Dataset"):
         fev.utils.generate_fingerprint(ds_dict)
+
+
+def test_when_sequence_col_entries_have_different_lengths_then_validate_dataset_raises_an_error():
+    N = 3
+    ds = datasets.Dataset.from_list(
+        [
+            {"id": "A", "timestamp": pd.date_range("2020", freq="D", periods=N), "target": list(range(N))},
+            {"id": "B", "timestamp": pd.date_range("2020", freq="D", periods=N), "target": list(range(N + 1))},
+        ]
+    )
+    with pytest.raises(AssertionError, match="Lengths of entries in"):
+        fev.utils.validate_time_series_dataset(ds)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Make `__version__` available via `from fev import __version__`
- Silence warnings from `datasets` when calling `ds.map(..., num_proc=num_proc)` with `num_proc > len(ds)`.
- Enable multivariate dataset support in `GluonTSAdapter`.
- Speed up `fev.utils.validate_time_series_dataset` for large datasets (down from 8s to 0.8s for `m5_with_covariates` dataset).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
