### PR TITLE
Minor fixes to `Task`

### DIFF
--- a/src/fev/task.py
+++ b/src/fev/task.py
@@ -843,7 +843,7 @@ class Task:
         eval_metric = metrics[0]
 
         metrics_per_window = {metric.name: [] for metric in metrics}
-        if isinstance(predictions_per_window, (datasets.Dataset, datasets.DatasetDict)):
+        if isinstance(predictions_per_window, (datasets.Dataset, datasets.DatasetDict, dict)):
             raise ValueError(
                 f"predictions_per_window must be iterable (e.g., a list) but got {type(predictions_per_window)}"
             )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Raise error if number of predictions does not match `task.num_windows`
- Disable tqdm progress bars by default when importing fev
- Gracefully handle deprecated task kwargs


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
