### PR TITLE
Make dependabot ignore examples/ folder

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "*"
-        paths:
-          - "examples/**"
+    exclude-paths:
+      - "examples/**"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Ignore the `examples/` folder


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
