### PR TITLE
Add support for datasets>=4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = { file = "LICENSE" }
 dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
-    "datasets>=2.15,<5.0",
+    "datasets>=3.0,<5.0",
     "pydantic~=2.0",
     "numpy",
     "scipy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = { file = "LICENSE" }
 dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
-    "datasets[s3]>=2.15,<4.0",
+    "datasets>=2.15,<5.0",
     "pydantic~=2.0",
     "numpy",
     "scipy",
@@ -39,6 +39,9 @@ Homepage = "https://github.com/autogluon/fev"
 Issues = "https://github.com/autogluon/fev/issues"
 
 [project.optional-dependencies]
+s3 = [
+    "s3fs",
+]
 test = [
     "pytest",
     "ruff",

--- a/src/fev/task.py
+++ b/src/fev/task.py
@@ -430,7 +430,6 @@ class Task:
     def load_full_dataset(
         self,
         storage_options: dict | None = None,
-        trust_remote_code: bool | None = None,
         num_proc: int = DEFAULT_NUM_PROC,
     ) -> datasets.Dataset:
         """Load the full raw dataset with preprocessing applied.
@@ -445,8 +444,6 @@ class Task:
         ----------
         storage_options : dict, optional
             Passed to `datasets.load_dataset()` for accessing remote datasets (e.g., S3 credentials).
-        trust_remote_code : bool, optional
-            Passed to `datasets.load_dataset()` for trusting remote code from Hugging Face Hub.
         num_proc : int, default DEFAULT_NUM_PROC
             Number of processes to use for dataset preprocessing.
 
@@ -456,15 +453,12 @@ class Task:
             The preprocessed dataset with all time series.
         """
         if self._full_dataset is None:
-            self._full_dataset = self._load_dataset(
-                storage_options=storage_options, trust_remote_code=trust_remote_code, num_proc=num_proc
-            )
+            self._full_dataset = self._load_dataset(storage_options=storage_options, num_proc=num_proc)
         return self._full_dataset
 
     def iter_windows(
         self,
         storage_options: dict | None = None,
-        trust_remote_code: bool | None = None,
         num_proc: int = DEFAULT_NUM_PROC,
     ) -> Iterable[EvaluationWindow]:
         """Iterate over the rolling evaluation windows in the task.
@@ -476,8 +470,6 @@ class Task:
         ----------
         storage_options : dict, optional
             Passed to `datasets.load_dataset()` for accessing remote datasets (e.g., S3 credentials).
-        trust_remote_code : bool, optional
-            Passed to `datasets.load_dataset()` for trusting remote code from Hugging Face Hub.
         num_proc : int, default DEFAULT_NUM_PROC
             Number of processes to use for dataset preprocessing.
 
@@ -493,15 +485,12 @@ class Task:
         ...     # Make predictions using past_data and future_data
         """
         for window_idx in range(self.num_windows):
-            yield self.get_window(
-                window_idx, storage_options=storage_options, trust_remote_code=trust_remote_code, num_proc=num_proc
-            )
+            yield self.get_window(window_idx, storage_options=storage_options, num_proc=num_proc)
 
     def get_window(
         self,
         window_idx: int,
         storage_options: dict | None = None,
-        trust_remote_code: bool | None = None,
         num_proc: int = DEFAULT_NUM_PROC,
     ) -> EvaluationWindow:
         """Get a single evaluation window by index.
@@ -512,8 +501,6 @@ class Task:
             Index of the evaluation window in [0, 1, ..., num_windows - 1].
         storage_options : dict, optional
             Passed to `datasets.load_dataset()` for accessing remote datasets (e.g., S3 credentials).
-        trust_remote_code : bool, optional
-            Passed to `datasets.load_dataset()` for trusting remote code from Hugging Face Hub.
         num_proc : int, default DEFAULT_NUM_PROC
             Number of processes to use for dataset preprocessing.
 
@@ -522,9 +509,7 @@ class Task:
         EvaluationWindow
             A single evaluation window at a specific cutoff containing the data needed to make and evaluate forecasts.
         """
-        full_dataset = self.load_full_dataset(
-            storage_options=storage_options, trust_remote_code=trust_remote_code, num_proc=num_proc
-        )
+        full_dataset = self.load_full_dataset(storage_options=storage_options, num_proc=num_proc)
         if window_idx >= self.num_windows:
             raise ValueError(f"Window index {window_idx} is out of range (num_windows={self.num_windows})")
         return EvaluationWindow(
@@ -585,7 +570,6 @@ class Task:
     def _load_dataset(
         self,
         storage_options: dict | None = None,
-        trust_remote_code: bool | None = None,
         num_proc: int = DEFAULT_NUM_PROC,
     ) -> datasets.Dataset:
         """Load the raw dataset and apply initial preprocessing based on the Task definition."""
@@ -613,7 +597,6 @@ class Task:
             data_files=data_files,
             split=datasets.Split.TRAIN,
             storage_options=copy.deepcopy(storage_options),
-            trust_remote_code=trust_remote_code,
         )
         try:
             ds = datasets.load_dataset(


### PR DESCRIPTION
*Issue #, if available:* Closes #103

### Summary
  - Add support for `datasets>=4.0`
  - Remove `trust_remote_code` parameter (removed in datasets 4.0)
  - Add `fev[s3]` optional extra for S3 support ([`datasets[s3]` was removed in 4.0](https://github.com/huggingface/datasets/pull/7616))

### Breaking changes
  - Datasets with custom loading scripts (e.g., https://huggingface.co/datasets/autogluon/chronos_datasets_extra) are no longer supported. Users need to use `fev<=0.7` to load them.
  - S3 support now requires `pip install fev[s3]` instead of being included by default

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
