### PR TITLE
Add model registry

### DIFF
--- a/src/fev/__about__.py
+++ b/src/fev/__about__.py
@@ -1,2 +1,2 @@
 # We cannot store __version__ in fev/__init__.py since that will introduce circular dependencies
-__version__ = "0.7.1"
+__version__ = "0.8.0rc1"

--- a/src/fev/__init__.py
+++ b/src/fev/__init__.py
@@ -2,6 +2,7 @@ from .__about__ import __version__
 from .adapters import convert_input_data
 from .analysis import leaderboard, pairwise_comparison, pivot_table
 from .benchmark import Benchmark
+from .model import ForecastingModel
 from .task import EvaluationWindow, Task
 from .utils import combine_univariate_predictions_to_multivariate, validate_time_series_dataset
 
@@ -9,6 +10,7 @@ __all__ = [
     "__version__",
     "Benchmark",
     "EvaluationWindow",
+    "ForecastingModel",
     "Task",
     "combine_univariate_predictions_to_multivariate",
     "convert_input_data",

--- a/src/fev/model.py
+++ b/src/fev/model.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import inspect
+import time
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Type
+
+import datasets
+from typing_extensions import Self
+
+if TYPE_CHECKING:
+    from .task import Task
+
+
+class ForecastingModel(ABC):
+    """Base class for forecasting model wrappers.
+
+    Subclasses are registered on import: importing a module that defines a concrete subclass
+    is sufficient for it to appear in `list_available_models()` / `get_model_cls()`.
+    Registry key is the class name with "Model" suffix stripped, lowercased.
+    """
+
+    _registry: dict[str, type] = {}
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if not inspect.isabstract(cls):
+            name = cls.__name__.removesuffix("Model").lower()
+            cls._registry[name] = cls
+
+    def __init__(self):
+        self.training_time: float = 0.0
+        self.inference_time: float = 0.0
+
+    @abstractmethod
+    def fit_predict(self, task: Task) -> list[datasets.DatasetDict]:
+        """Must be implemented by all models. Produce predictions for all windows in the task."""
+        ...
+
+    @classmethod
+    def list_available_models(cls) -> list[str]:
+        """Return names of all registered (imported) model subclasses."""
+        return sorted(cls._registry.keys())
+
+    @classmethod
+    def get_model_cls(cls, model_name: str) -> Type[Self]:
+        """Look up a registered model class by name. Raises ValueError if not found."""
+        model_name = model_name.lower()
+        if model_name not in cls._registry:
+            available = cls.list_available_models()
+            raise ValueError(f"Unknown model '{model_name}'. Available: {available}")
+        return cls._registry[model_name]
+
+    @contextmanager
+    def _record_training_time(self):
+        """Context manager that accumulates elapsed time into self.training_time."""
+        start = time.monotonic()
+        try:
+            yield
+        finally:
+            self.training_time += time.monotonic() - start
+
+    @contextmanager
+    def _record_inference_time(self):
+        """Context manager that accumulates elapsed time into self.inference_time."""
+        start = time.monotonic()
+        try:
+            yield
+        finally:
+            self.inference_time += time.monotonic() - start

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,0 +1,49 @@
+import pytest
+
+from fev.model import ForecastingModel
+
+
+class DummyModel(ForecastingModel):
+    def fit_predict(self, task):
+        return []
+
+
+class AnotherFancyModel(ForecastingModel):
+    def fit_predict(self, task):
+        return []
+
+
+def test_when_concrete_subclass_defined_then_it_is_registered():
+    assert "dummy" in ForecastingModel.list_available_models()
+    assert "anotherfancy" in ForecastingModel.list_available_models()
+
+
+def test_when_get_model_cls_called_then_correct_class_returned():
+    assert ForecastingModel.get_model_cls("dummy") is DummyModel
+    assert ForecastingModel.get_model_cls("Dummy") is DummyModel
+
+
+def test_when_unknown_model_requested_then_error_is_raised():
+    with pytest.raises(ValueError, match="Unknown model"):
+        ForecastingModel.get_model_cls("nonexistent")
+
+
+def test_when_abstract_class_instantiated_then_error_is_raised():
+    with pytest.raises(TypeError):
+        ForecastingModel()
+
+
+def test_when_record_training_time_used_then_training_time_updated():
+    model = DummyModel()
+    assert model.training_time == 0.0
+    with model._record_training_time():
+        pass
+    assert model.training_time > 0.0
+
+
+def test_when_record_inference_time_used_then_inference_time_updated():
+    model = DummyModel()
+    assert model.inference_time == 0.0
+    with model._record_inference_time():
+        pass
+    assert model.inference_time > 0.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Bump version to `0.8.0rc1`
-  Add `fev.ForecastingModel` — a minimal ABC for model wrappers. Concrete subclasses are auto-registered on import via `__init_subclass__`, discoverable through `list_available_models()` and `get_model_cls()`. Includes timing utilities and unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
