### PR TITLE
Refactor the model evaluation scripts

### DIFF
--- a/models/README.md
+++ b/models/README.md
@@ -1,0 +1,54 @@
+# Model Wrappers
+
+Each subfolder contains a forecasting model wrapper. Below is how to run evaluation for existing wrappers and how to add your own.
+
+## Prerequisites
+
+```bash
+# Install uv (if not already installed)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Clone the repo and install fev in editable mode
+git clone https://github.com/autogluon/fev.git
+cd fev
+uv pip install -e .
+```
+
+## Evaluate a model
+
+```bash
+python models/evaluate.py -m chronos2
+```
+
+Options:
+- `-m` — model name (must match a subfolder in `models/`)
+- `-b` — path or URL to benchmark YAML (default: `fev_bench_mini`)
+- `-n` — display name for results (default: same as `-m`)
+- `-k` — JSON dict of kwargs passed to the model constructor
+- `-t` — limit number of tasks (useful for quick testing)
+
+Model dependencies are installed automatically in an ephemeral environment. Your project environment is not modified.
+
+## Add a custom model
+
+1. Create a folder `models/<name>/` where `<name>` is how you'll refer to the model with `-m`.
+
+2. Add `model.py` with a subclass of `ForecastingModel`. Set `model_name` to match the folder name.
+
+```python
+import datasets
+import fev
+from fev.model import ForecastingModel
+
+class MyModel(ForecastingModel):
+    model_name = "my-model"  # must match the folder name
+
+    def __init__(self, model_size: str = "small"):
+        super().__init__()
+        self.model_size = model_size
+
+    def _fit_predict(self, task: fev.Task) -> list[datasets.DatasetDict]:
+        ...
+```
+
+3. Add `requirements.txt` with pinned dependencies for the model.

--- a/models/README.md
+++ b/models/README.md
@@ -17,7 +17,7 @@ uv pip install -e .
 ## Evaluate a model
 
 ```bash
-python models/evaluate.py -m chronos2
+python models/evaluate.py -m chronos
 ```
 
 Options:

--- a/models/chronos/model.py
+++ b/models/chronos/model.py
@@ -1,0 +1,34 @@
+import datasets
+import torch
+from chronos import BaseChronosPipeline
+
+import fev
+from fev.model import ForecastingModel
+
+
+class ChronosModel(ForecastingModel):
+    """Chronos-Bolt model from https://github.com/amazon-science/chronos-forecasting."""
+
+    model_name = "chronos"
+
+    def __init__(
+        self,
+        model_path: str = "amazon/chronos-bolt-base",
+        device_map: str = "cuda",
+        torch_dtype: torch.dtype = torch.bfloat16,
+        batch_size: int = 32,
+    ):
+        super().__init__()
+        self.model_path = model_path
+        self.device_map = device_map
+        self.torch_dtype = torch_dtype
+        self.batch_size = batch_size
+
+    def _fit_predict(self, task: fev.Task) -> list[datasets.DatasetDict]:
+        pipeline = BaseChronosPipeline.from_pretrained(
+            self.model_path, device_map=self.device_map, torch_dtype=self.torch_dtype
+        )
+
+        predictions_per_window, self.inference_time = pipeline.predict_fev(task, batch_size=self.batch_size)
+
+        return predictions_per_window

--- a/models/chronos/requirements.txt
+++ b/models/chronos/requirements.txt
@@ -1,0 +1,1 @@
+chronos-forecasting==2.2.2

--- a/models/evaluate.py
+++ b/models/evaluate.py
@@ -1,0 +1,81 @@
+"""Evaluate a model on all tasks in a benchmark. See models/README.md for usage."""
+
+import argparse
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_MODELS_DIR = Path(__file__).parent
+_DEFAULT_BENCHMARK = (
+    "https://raw.githubusercontent.com/autogluon/fev/refs/heads/main/benchmarks/fev_bench/tasks_mini.yaml"
+)
+
+
+def list_available_models() -> list[str]:
+    return sorted(d.name for d in _MODELS_DIR.iterdir() if (d / "model.py").exists())
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Evaluate a model on a benchmark.")
+    parser.add_argument("-m", "--model", required=True, help="Model name (must match a folder in models/)")
+    parser.add_argument("-b", "--benchmark", default=_DEFAULT_BENCHMARK, help="Path or URL to benchmark YAML")
+    parser.add_argument("-n", "--name", default=None, help="Display name for results (defaults to --model)")
+    parser.add_argument("-k", "--model-kwargs", default="{}", help="JSON dict of kwargs passed to model constructor")
+    parser.add_argument("-t", "--num-tasks", type=int, default=None, help="Limit number of tasks (for testing)")
+    parser.add_argument("-d", "--deps-installed", action="store_true", help=argparse.SUPPRESS)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    model_dir = _MODELS_DIR / args.model
+
+    if not (model_dir / "model.py").exists():
+        sys.exit(f"Model '{args.model}' not found. Available: {list_available_models()}")
+
+    # Re-exec in ephemeral env with model deps if needed
+    requirements_path = model_dir / "requirements.txt"
+    if not args.deps_installed and requirements_path.exists():
+        cmd = ["uv", "run", f"--with-requirements={requirements_path}", sys.argv[0]] + sys.argv[1:] + ["-d"]
+        sys.exit(subprocess.run(cmd).returncode)
+
+    import pandas as pd
+    from tqdm import tqdm
+
+    import fev
+    from fev.model import ForecastingModel
+
+    spec = importlib.util.spec_from_file_location(f"models.{args.model}", model_dir / "model.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    model_cls = ForecastingModel.get_model_cls(args.model)
+    model = model_cls(**json.loads(args.model_kwargs))
+    display_name = args.name or args.model
+
+    benchmark = fev.Benchmark.from_yaml(args.benchmark)
+    tasks = benchmark.tasks[: args.num_tasks]
+
+    summaries = []
+    for task in tqdm(tasks):
+        tqdm.write(f"Evaluating {task.task_name}")
+        predictions = model.fit_predict(task)
+        summary = task.evaluation_summary(
+            predictions,
+            model_name=display_name,
+            training_time_s=model.training_time,
+            inference_time_s=model.inference_time,
+        )
+        summaries.append(summary)
+
+    df = pd.DataFrame(summaries)
+    print(df.to_string())
+    output_path = f"{display_name}.csv"
+    df.to_csv(output_path, index=False)
+    print(f"Saved to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fev/model.py
+++ b/src/fev/model.py
@@ -16,26 +16,47 @@ if TYPE_CHECKING:
 class ForecastingModel(ABC):
     """Base class for forecasting model wrappers.
 
-    Subclasses are registered on import: importing a module that defines a concrete subclass
-    is sufficient for it to appear in `list_available_models()` / `get_model_cls()`.
-    Registry key is the class name with "Model" suffix stripped, lowercased.
+    Concrete subclasses are registered on import and discoverable via `get_model_cls()`.
+
+    How to implement a subclass:
+    - Set `model_name` class attribute if the default doesn't work for you.
+    - Implement _fit_predict(task) -> predictions for all windows in the task.
+    - Each _fit_predict call should be independent (don't carry over state from prior tasks).
+    - Caching expensive resources (weights, tokenizers) on self across calls is fine.
     """
 
     _registry: dict[str, type] = {}
+    model_name: str | None = None
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
         if not inspect.isabstract(cls):
-            name = cls.__name__.removesuffix("Model").lower()
-            cls._registry[name] = cls
+            if cls.model_name is None:
+                cls.model_name = cls.__name__.removesuffix("Model").lower()
+            if cls.model_name in cls._registry and cls._registry[cls.model_name] is not cls:
+                raise ValueError(
+                    f"Model name '{cls.model_name}' is already registered by "
+                    f"{cls._registry[cls.model_name].__qualname__}"
+                )
+            cls._registry[cls.model_name] = cls
 
     def __init__(self):
+        # Set these directly or use _record_training_time / _record_inference_time helpers
         self.training_time: float = 0.0
         self.inference_time: float = 0.0
 
-    @abstractmethod
     def fit_predict(self, task: Task) -> list[datasets.DatasetDict]:
-        """Must be implemented by all models. Produce predictions for all windows in the task."""
+        """Produce predictions for all windows in the task.
+
+        Resets timing attributes before each call. Subclasses implement `_fit_predict`.
+        """
+        self.training_time = 0.0
+        self.inference_time = 0.0
+        return self._fit_predict(task)
+
+    @abstractmethod
+    def _fit_predict(self, task: Task) -> list[datasets.DatasetDict]:
+        """Implement this. Called by `fit_predict` after timing is reset."""
         ...
 
     @classmethod
@@ -45,8 +66,7 @@ class ForecastingModel(ABC):
 
     @classmethod
     def get_model_cls(cls, model_name: str) -> Type[Self]:
-        """Look up a registered model class by name. Raises ValueError if not found."""
-        model_name = model_name.lower()
+        """Look up a registered model class by name (exact match). Raises ValueError if not found."""
         if model_name not in cls._registry:
             available = cls.list_available_models()
             raise ValueError(f"Unknown model '{model_name}'. Available: {available}")
@@ -54,7 +74,7 @@ class ForecastingModel(ABC):
 
     @contextmanager
     def _record_training_time(self):
-        """Context manager that accumulates elapsed time into self.training_time."""
+        """Optional helper. Accumulates elapsed time into self.training_time."""
         start = time.monotonic()
         try:
             yield
@@ -63,7 +83,7 @@ class ForecastingModel(ABC):
 
     @contextmanager
     def _record_inference_time(self):
-        """Context manager that accumulates elapsed time into self.inference_time."""
+        """Optional helper. Accumulates elapsed time into self.inference_time."""
         start = time.monotonic()
         try:
             yield

--- a/src/fev/model.py
+++ b/src/fev/model.py
@@ -66,7 +66,8 @@ class ForecastingModel(ABC):
 
     @classmethod
     def get_model_cls(cls, model_name: str) -> Type[Self]:
-        """Look up a registered model class by name (exact match). Raises ValueError if not found."""
+        """Look up a registered model class by name (case-insensitive). Raises ValueError if not found."""
+        model_name = model_name.lower()
         if model_name not in cls._registry:
             available = cls.list_available_models()
             raise ValueError(f"Unknown model '{model_name}'. Available: {available}")

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,15 +1,21 @@
+import time
+
 import pytest
 
 from fev.model import ForecastingModel
 
 
 class DummyModel(ForecastingModel):
-    def fit_predict(self, task):
+    def _fit_predict(self, task):
+        with self._record_training_time():
+            time.sleep(0.01)
+        with self._record_inference_time():
+            time.sleep(0.01)
         return []
 
 
 class AnotherFancyModel(ForecastingModel):
-    def fit_predict(self, task):
+    def _fit_predict(self, task):
         return []
 
 
@@ -20,7 +26,7 @@ def test_when_concrete_subclass_defined_then_it_is_registered():
 
 def test_when_get_model_cls_called_then_correct_class_returned():
     assert ForecastingModel.get_model_cls("dummy") is DummyModel
-    assert ForecastingModel.get_model_cls("Dummy") is DummyModel
+    assert DummyModel.model_name == "dummy"
 
 
 def test_when_unknown_model_requested_then_error_is_raised():
@@ -33,17 +39,37 @@ def test_when_abstract_class_instantiated_then_error_is_raised():
         ForecastingModel()
 
 
-def test_when_record_training_time_used_then_training_time_updated():
+def test_when_fit_predict_called_then_timing_is_reset_and_recorded():
     model = DummyModel()
-    assert model.training_time == 0.0
-    with model._record_training_time():
-        pass
-    assert model.training_time > 0.0
+    model.training_time = 99.0
+    model.inference_time = 99.0
+    model.fit_predict(task=None)
+    assert 0.01 <= model.training_time < 1.0
+    assert 0.01 <= model.inference_time < 1.0
 
 
-def test_when_record_inference_time_used_then_inference_time_updated():
+def test_when_fit_predict_called_twice_then_timing_reflects_only_last_call():
     model = DummyModel()
-    assert model.inference_time == 0.0
-    with model._record_inference_time():
-        pass
-    assert model.inference_time > 0.0
+    model.fit_predict(task=None)
+    model.fit_predict(task=None)
+    assert model.training_time < 1.0
+    assert model.inference_time < 1.0
+
+
+def test_when_model_name_set_then_registered_under_custom_name():
+    class MyWeirdModel(ForecastingModel):
+        model_name = "timesfm-2.5"
+
+        def _fit_predict(self, task):
+            return []
+
+    assert "timesfm-2.5" in ForecastingModel.list_available_models()
+    assert ForecastingModel.get_model_cls("timesfm-2.5") is MyWeirdModel
+
+
+def test_when_duplicate_model_name_registered_then_error_is_raised():
+    with pytest.raises(ValueError, match="already registered"):
+
+        class DummyModel(ForecastingModel):  # noqa: F811
+            def _fit_predict(self, task):
+                return []

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -26,6 +26,7 @@ def test_when_concrete_subclass_defined_then_it_is_registered():
 
 def test_when_get_model_cls_called_then_correct_class_returned():
     assert ForecastingModel.get_model_cls("dummy") is DummyModel
+    assert ForecastingModel.get_model_cls("Dummy") is DummyModel
     assert DummyModel.model_name == "dummy"
 
 
@@ -57,14 +58,14 @@ def test_when_fit_predict_called_twice_then_timing_reflects_only_last_call():
 
 
 def test_when_model_name_set_then_registered_under_custom_name():
-    class MyWeirdModel(ForecastingModel):
+    class MyCustomModel(ForecastingModel):
         model_name = "timesfm-2.5"
 
         def _fit_predict(self, task):
             return []
 
     assert "timesfm-2.5" in ForecastingModel.list_available_models()
-    assert ForecastingModel.get_model_cls("timesfm-2.5") is MyWeirdModel
+    assert ForecastingModel.get_model_cls("timesfm-2.5") is MyCustomModel
 
 
 def test_when_duplicate_model_name_registered_then_error_is_raised():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
  - Adds `models/` directory with new format for model wrappers — each with `model.py` + pinned `requirements.txt`
  - Adds `models/evaluate.py` — shared evaluation script that auto-installs model deps in an ephemeral env via `uv run --with-requirements`
  - Updates `ForecastingModel`: template method (timing reset per call), duplicate name detection, `model_name` class attribute, case-insensitive lookup
  - Adds `models/README.md` documenting prerequisites, usage, and how to add new models

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
