### PR TITLE
Add leakge info to model wrappers

### DIFF
--- a/models/README.md
+++ b/models/README.md
@@ -43,6 +43,10 @@ from fev.model import ForecastingModel
 class MyModel(ForecastingModel):
     model_name = "my-model"  # must match the folder name
 
+    # List HF dataset configs (from autogluon/fev_datasets) used during pretraining.
+    # This is used to flag potential data leakage during evaluation.
+    trained_on_datasets = ["kdd_cup_2022_10T", "m5_1D"]
+
     def __init__(self, model_size: str = "small"):
         super().__init__()
         self.model_size = model_size
@@ -52,3 +56,5 @@ class MyModel(ForecastingModel):
 ```
 
 3. Add `requirements.txt` with pinned dependencies for the model.
+
+4. For pretrained models, set `trained_on_datasets` to the list of dataset configs from `autogluon/fev_datasets` that overlap with the model's training data. Leave empty for models that train from scratch.

--- a/models/evaluate.py
+++ b/models/evaluate.py
@@ -66,6 +66,7 @@ def main():
             model_name=display_name,
             training_time_s=model.training_time,
             inference_time_s=model.inference_time,
+            trained_on_this_dataset=task.dataset_config in model.trained_on_datasets,
         )
         summaries.append(summary)
 

--- a/models/moirai/model.py
+++ b/models/moirai/model.py
@@ -11,6 +11,35 @@ class MoiraiModel(fev.ForecastingModel):
     """Moirai v2 from https://huggingface.co/Salesforce/moirai-2.0-R-small."""
 
     model_name = "moirai"
+    trained_on_datasets = [
+        "ETT_15T",
+        "ETT_1D",
+        "ETT_1H",
+        "ETT_1W",
+        "LOOP_SEATTLE_1D",
+        "LOOP_SEATTLE_1H",
+        "LOOP_SEATTLE_5T",
+        "M_DENSE_1D",
+        "M_DENSE_1H",
+        "SZ_TAXI_15T",
+        "SZ_TAXI_1H",
+        "bizitobs_l2c_1H",
+        "bizitobs_l2c_5T",
+        "favorita_transactions_1D",
+        "fred_md_2025",
+        "hierarchical_sales_1D",
+        "hierarchical_sales_1W",
+        "hospital",
+        "jena_weather_10T",
+        "jena_weather_1D",
+        "jena_weather_1H",
+        "kdd_cup_2022_10T",
+        "m5_1D",
+        "proenfo_gfc12",
+        "proenfo_gfc14",
+        "proenfo_gfc17",
+        "restaurant",
+    ]
 
     def __init__(
         self,

--- a/models/sundial/model.py
+++ b/models/sundial/model.py
@@ -10,6 +10,9 @@ class SundialModel(fev.ForecastingModel):
     """Sundial model from https://huggingface.co/thuml/sundial-base-128m."""
 
     model_name = "sundial"
+    trained_on_datasets = [
+        "kdd_cup_2022_10T",
+    ]
 
     def __init__(
         self,

--- a/models/timesfm-2.5/model.py
+++ b/models/timesfm-2.5/model.py
@@ -8,6 +8,17 @@ class TimesFM25Model(fev.ForecastingModel):
     """TimesFM 2.5 model from https://github.com/google-research/timesfm."""
 
     model_name = "timesfm-2.5"
+    trained_on_datasets = [
+        "favorita_transactions_1D",
+        "favorita_transactions_1W",
+        "fred_md_2025",
+        "proenfo_gfc12",
+        "proenfo_gfc14",
+        "proenfo_gfc17",
+        "kdd_cup_2022_10T",
+        "m5_1D",
+        "m5_1W",
+    ]
     TIMESFM_MODEL_QUANTILES = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
 
     def __init__(

--- a/models/tirex/model.py
+++ b/models/tirex/model.py
@@ -10,6 +10,9 @@ class TiRexModel(fev.ForecastingModel):
     """TiRex model from https://github.com/NX-AI/tirex."""
 
     model_name = "tirex"
+    trained_on_datasets = [
+        "kdd_cup_2022_10T",
+    ]
 
     def __init__(
         self,

--- a/models/toto-1.0/model.py
+++ b/models/toto-1.0/model.py
@@ -10,6 +10,15 @@ class TotoModel(fev.ForecastingModel):
     """Toto model from https://github.com/DataDog/toto."""
 
     model_name = "toto-1.0"
+    trained_on_datasets = [
+        "favorita_transactions_1D",
+        "fred_md_2025",
+        "proenfo_gfc12",
+        "proenfo_gfc14",
+        "proenfo_gfc17",
+        "kdd_cup_2022_10T",
+        "m5_1D",
+    ]
 
     def __init__(
         self,

--- a/src/fev/model.py
+++ b/src/fev/model.py
@@ -23,10 +23,14 @@ class ForecastingModel(ABC):
     - Implement _fit_predict(task) -> predictions for all windows in the task.
     - Each _fit_predict call should be independent (don't carry over state from prior tasks).
     - Caching expensive resources (weights, tokenizers) on self across calls is fine.
+    - For pretrained models, set `trained_on_datasets` to the list of HF dataset configs
+      (from autogluon/fev_datasets) that were in the model's training data. This is used
+      to flag potential data leakage during evaluation.
     """
 
     _registry: dict[str, type] = {}
     model_name: str | None = None
+    trained_on_datasets: list[str] = []
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add attribute `trained_on_datasets` to `fev.model.ForecastingModel` that indicates which datasets were seen during pretraining.
- Use leakage info in `models/evaluate.py`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
