### PR TITLE
Speed up data conversion with pyarrow operations

### DIFF
--- a/src/fev/adapters.py
+++ b/src/fev/adapters.py
@@ -58,21 +58,21 @@ class PandasAdapter(DatasetAdapter):
 
     @staticmethod
     def _to_long_df(dataset: datasets.Dataset, id_column: str) -> pd.DataFrame:
-        """Convert time series dataset into long DataFrame format.
+        """Convert time series dataset into long DataFrame format via pyarrow."""
+        import pyarrow as pa
+        import pyarrow.compute as pc
 
-        Parameters
-        ----------
-        dataset
-            Dataset that must be converted.
-        """
-        df: pd.DataFrame = dataset.to_pandas()
-        # Equivalent to df.explode() but much faster
-        length_per_item = df[df.columns.drop(id_column)[0]].apply(len).to_numpy()
-        df_dict = {id_column: np.repeat(df[id_column].to_numpy(), length_per_item)}
-        for col in df.columns:
-            if col != id_column:
-                df_dict[col] = np.concatenate(df[col])
-        return pd.DataFrame(df_dict).astype({id_column: str})
+        if getattr(dataset, "_indices", None) is not None:
+            dataset = dataset.flatten_indices()
+        table = dataset.data.table
+        seq_cols = [col for col in table.column_names if col != id_column]
+        lengths = pc.list_value_length(table.column(seq_cols[0])).to_numpy()
+
+        repeat_indices = np.repeat(np.arange(table.num_rows), lengths)
+        flat_data = {id_column: table.column(id_column).take(repeat_indices)}
+        for col in seq_cols:
+            flat_data[col] = pc.list_flatten(table.column(col))
+        return pa.table(flat_data).to_pandas()
 
     @classmethod
     def convert_input_data(

--- a/src/fev/utils.py
+++ b/src/fev/utils.py
@@ -1,6 +1,5 @@
 import reprlib
 import warnings
-from collections import defaultdict
 
 import datasets
 import multiprocess as mp
@@ -229,27 +228,6 @@ def generate_fingerprint(dataset: datasets.Dataset, num_rows_to_check: int = 3) 
         return None
 
 
-def _expand_target_columns(
-    batch: dict, id_column: str, target_column: str, generate_univariate_targets_from: list[str]
-) -> dict:
-    """Create a separate record for each column listed in generate_univariate_targets_from.
-
-    It is required to set batched=True when using method in `dataset.map`.
-    """
-    expanded_batch = defaultdict(list)
-    batch_size = len(batch[id_column])
-    for i in range(batch_size):
-        for target_col in generate_univariate_targets_from:
-            for key in batch.keys():
-                if key not in generate_univariate_targets_from:
-                    value = batch[key][i]
-                    if key == id_column:
-                        value = value + "_" + target_col
-                    expanded_batch[key].append(value)
-            expanded_batch[target_column].append(batch[target_col][i])
-    return dict(expanded_batch)
-
-
 def generate_univariate_targets_from_multivariate(
     dataset: datasets.Dataset,
     id_column: str,
@@ -264,7 +242,7 @@ def generate_univariate_targets_from_multivariate(
 
     Parameters
     ----------
-    ds
+    dataset
         Input multivariate time series dataset.
     id_column
         Column containing unique time series identifiers.
@@ -275,17 +253,33 @@ def generate_univariate_targets_from_multivariate(
     num_proc
         Number of processes for parallel processing.
     """
-    return dataset.map(
-        _expand_target_columns,
-        batched=True,
-        fn_kwargs=dict(
-            id_column=id_column,
-            target_column=new_target_column,
-            generate_univariate_targets_from=generate_univariate_targets_from,
-        ),
-        remove_columns=generate_univariate_targets_from,
-        num_proc=min(num_proc, len(dataset)),
-    )
+    if getattr(dataset, "_indices", None) is not None:
+        dataset = dataset.flatten_indices()
+
+    table = dataset.data.table
+    N = table.num_rows
+    D = len(generate_univariate_targets_from)
+
+    # Each original row becomes D rows (one per target column)
+    row_indices = np.arange(N).repeat(D)
+
+    # Build new ID column: "{original_id}_{target_col_name}"
+    ids = table.column(id_column).to_pylist()
+    new_ids = [f"{ids[i]}_{col}" for i in range(N) for col in generate_univariate_targets_from]
+
+    # Copy non-target columns (repeated D times per row)
+    new_columns = {id_column: pa.array(new_ids)}
+    for col in table.column_names:
+        if col != id_column and col not in generate_univariate_targets_from:
+            new_columns[col] = table.column(col).take(row_indices)
+
+    # Interleave target columns: for row i we want [target_0[i], target_1[i], ..., target_D[i]]
+    # Stack as [D, N] then transpose+flatten to get [N*D] in interleaved order
+    stacked = pa.concat_arrays([table.column(col).combine_chunks() for col in generate_univariate_targets_from])
+    interleave_idx = np.arange(D * N).reshape(D, N).T.ravel()
+    new_columns[new_target_column] = stacked.take(interleave_idx)
+
+    return datasets.Dataset(pa.table(new_columns))
 
 
 def convert_forecast_df_to_predictions(
@@ -361,9 +355,11 @@ def combine_univariate_predictions_to_multivariate(
     assert len(predictions) % len(target_columns) == 0, (
         "Number of predictions must be divisible by the number of target columns"
     )
+    table = predictions.data.table
     prediction_dict = {}
     for i, col in enumerate(target_columns):
-        prediction_dict[col] = predictions.select(range(i, len(predictions), len(target_columns)))
+        indices = list(range(i, len(predictions), len(target_columns)))
+        prediction_dict[col] = datasets.Dataset(table.take(indices))
     return datasets.DatasetDict(prediction_dict)
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -5,7 +5,7 @@ import pytest
 from datasets import Dataset
 
 import fev
-from fev.utils import past_future_split
+from fev.utils import generate_univariate_targets_from_multivariate, past_future_split
 
 
 def test_when_dataset_info_is_changed_then_dataset_fingerprint_doesnt_change():
@@ -285,3 +285,93 @@ def test_when_dataset_has_numpy_format_then_output_preserves_format():
     assert past.format["type"] == "numpy"
     assert future.format["type"] == "numpy"
     assert isinstance(past[0]["target"], np.ndarray)
+
+
+# generate_univariate_targets_from_multivariate tests
+
+
+def _make_multivariate_dataset(ids, lengths, target_cols, extra_cols=None):
+    """Helper to build a multivariate time series dataset."""
+    records = []
+    for id_, length in zip(ids, lengths):
+        record = {
+            "id": id_,
+            "timestamp": pd.date_range("2020", freq="D", periods=length),
+        }
+        for col in target_cols:
+            record[col] = [float(hash((id_, col, t)) % 100) for t in range(length)]
+        if extra_cols:
+            for col, val in extra_cols.items():
+                record[col] = val if not isinstance(val, list) else [val[0]] * length
+        records.append(record)
+    return Dataset.from_list(records)
+
+
+def test_when_single_item_two_targets_then_expanded_correctly():
+    ds = _make_multivariate_dataset(["A"], [5], ["X", "Y"])
+    result = generate_univariate_targets_from_multivariate(
+        ds, id_column="id", new_target_column="target", generate_univariate_targets_from=["X", "Y"]
+    )
+    assert len(result) == 2
+    assert result[0]["id"] == "A_X"
+    assert result[1]["id"] == "A_Y"
+    assert list(result[0]["target"]) == list(ds[0]["X"])
+    assert list(result[1]["target"]) == list(ds[0]["Y"])
+
+
+def test_when_multiple_items_then_interleaved_correctly():
+    ds = _make_multivariate_dataset(["A", "B"], [3, 3], ["X", "Y"])
+    result = generate_univariate_targets_from_multivariate(
+        ds, id_column="id", new_target_column="target", generate_univariate_targets_from=["X", "Y"]
+    )
+    assert len(result) == 4
+    assert [result[i]["id"] for i in range(4)] == ["A_X", "A_Y", "B_X", "B_Y"]
+    assert list(result[0]["target"]) == list(ds[0]["X"])
+    assert list(result[1]["target"]) == list(ds[0]["Y"])
+    assert list(result[2]["target"]) == list(ds[1]["X"])
+    assert list(result[3]["target"]) == list(ds[1]["Y"])
+
+
+def test_when_non_target_columns_present_then_they_are_repeated():
+    ds = Dataset.from_list(
+        [
+            {
+                "id": "A",
+                "timestamp": pd.date_range("2020", freq="D", periods=3),
+                "X": [1.0, 2.0, 3.0],
+                "Y": [10.0, 20.0, 30.0],
+                "covariate": [100.0, 200.0, 300.0],
+            }
+        ]
+    )
+    result = generate_univariate_targets_from_multivariate(
+        ds, id_column="id", new_target_column="target", generate_univariate_targets_from=["X", "Y"]
+    )
+    assert len(result) == 2
+    assert list(result[0]["covariate"]) == [100.0, 200.0, 300.0]
+    assert list(result[1]["covariate"]) == [100.0, 200.0, 300.0]
+    assert list(result[0]["timestamp"]) == list(result[1]["timestamp"])
+
+
+def test_when_items_have_different_lengths_then_expanded_correctly():
+    ds = _make_multivariate_dataset(["A", "B"], [3, 5], ["X", "Y"])
+    result = generate_univariate_targets_from_multivariate(
+        ds, id_column="id", new_target_column="target", generate_univariate_targets_from=["X", "Y"]
+    )
+    assert len(result) == 4
+    assert len(result[0]["target"]) == 3  # A_X
+    assert len(result[1]["target"]) == 3  # A_Y
+    assert len(result[2]["target"]) == 5  # B_X
+    assert len(result[3]["target"]) == 5  # B_Y
+
+
+def test_when_dataset_has_indices_then_flattened_before_expansion():
+    ds = _make_multivariate_dataset(["A", "B", "C"], [3, 3, 3], ["X", "Y"])
+    ds_filtered = ds.select([0, 2])  # creates lazy _indices
+    assert ds_filtered._indices is not None
+    result = generate_univariate_targets_from_multivariate(
+        ds_filtered, id_column="id", new_target_column="target", generate_univariate_targets_from=["X", "Y"]
+    )
+    assert len(result) == 4
+    assert result[0]["id"] == "A_X"
+    assert result[2]["id"] == "C_X"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Rewrite `generate_univariate_targets_from_multivariate` using pyarrow table operations instead of `dataset.map` with Python loops (10x faster)
- Rewrite `PandasAdapter._to_long_df` to build flat pyarrow table then `to_pandas()`, avoiding `np.repeat` on strings (10x faster)
- Fix `combine_univariate_predictions_to_multivariate` to use `table.take()` instead of `Dataset.select()` to avoid lazy `_indices` views
- `convert_input_data` per window: 318ms -> 94ms (e.g. saving 6s of runtime on 1 boomlet task)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
