### PR TITLE
Fix docs deploy CI permissions and document build commands

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,9 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write  # mike pushes the built site to the gh-pages branch
 
 jobs:
   deploy:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,36 @@
+# Documentation
+
+The docs are built with [MkDocs](https://www.mkdocs.org/) (Material theme) and versioned with
+[mike](https://github.com/jimporter/mike). Config lives in `mkdocs.yml`; doc dependencies are in
+`docs/requirements.txt`.
+
+CI (`.github/workflows/docs.yml`) deploys automatically on every `v*` tag push. The commands below
+are for building locally or deploying manually (e.g. re-deploying a release that's already on PyPI).
+
+All commands use `uv` to create an ephemeral environment — the `--with-requirements` deps are layered
+on top of the project itself (needed so `mkdocstrings` can import `fev`). Run them from the repo root.
+
+## Preview locally
+
+```bash
+uv run --with-requirements docs/requirements.txt mkdocs serve
+```
+
+Opens a live-reloading preview at http://127.0.0.1:8000.
+
+## Build only (no deploy)
+
+```bash
+uv run --with-requirements docs/requirements.txt mkdocs build
+```
+
+Outputs the static site to `site/`.
+
+## Deploy manually
+
+`mike` pushes the built site to the `gh-pages` branch. Replace `X.Y.Z` with the released version
+(matching the `vX.Y.Z` tag), which also updates the `latest` alias:
+
+```bash
+uv run --with-requirements docs/requirements.txt mike deploy --push --update-aliases X.Y.Z latest
+```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material
-mkdocs-jupyter
-mkdocstrings[python]
-mike
+mkdocs-material==9.7.6
+mkdocs-jupyter==0.26.3
+mkdocstrings[python]==1.0.4
+mike==2.2.0


### PR DESCRIPTION
## Summary

The docs deploy workflow (`.github/workflows/docs.yml`) builds the site successfully but fails when `mike` pushes to `gh-pages`:

```
remote: Permission to autogluon/fev.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/autogluon/fev/': The requested URL returned error: 403
```

`mike deploy --push` commits the built site to the `gh-pages` branch, which needs `contents: write`. The workflow granted `contents: read` (plus `pages`/`id-token` write, which `mike` doesn't use since it pushes to a branch rather than the Pages artifact API).

## Changes

- **`docs.yml`**: replace `contents: read` + `pages: write` + `id-token: write` with `contents: write` so the CI token can push to `gh-pages`.
- **`docs/requirements.txt`**: pin docs dependency versions for reproducible/secure builds.
- **`docs/README.md`**: document local preview/build and manual deploy commands (via `uv` ephemeral envs).