### PR TITLE
Use uv for CI installs and shorten leaderboard preview name

### DIFF
--- a/.github/workflows/benchmark-submission.yml
+++ b/.github/workflows/benchmark-submission.yml
@@ -18,10 +18,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
         run: uv pip install --system . pandas pyyaml

--- a/.github/workflows/benchmark-submission.yml
+++ b/.github/workflows/benchmark-submission.yml
@@ -25,9 +25,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: |
-          uv venv
-          uv pip install . pandas pyyaml
+        run: uv pip install . pandas pyyaml
 
       - name: Print leaderboard
         run: uv run python scripts/render_fev_bench_leaderboard.py

--- a/.github/workflows/benchmark-submission.yml
+++ b/.github/workflows/benchmark-submission.yml
@@ -1,4 +1,4 @@
-name: fev-bench leaderboard preview
+name: Leaderboard preview
 
 # Read-only, no secrets. Prints the leaderboard for benchmarks/ PRs so reviewers can eyeball a
 # submission. Submission *validation* lives in ci.yml (test/test_fev_bench_submissions.py, run on
@@ -18,13 +18,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: pip install ".[test]"
+        run: uv pip install --system . pandas pyyaml
 
       - name: Print leaderboard
         run: python scripts/render_fev_bench_leaderboard.py

--- a/.github/workflows/benchmark-submission.yml
+++ b/.github/workflows/benchmark-submission.yml
@@ -18,16 +18,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.11"
+          enable-cache: true
 
       - name: Install dependencies
-        run: uv pip install --system . pandas pyyaml
+        run: |
+          uv venv
+          uv pip install . pandas pyyaml
 
       - name: Print leaderboard
-        run: python scripts/render_fev_bench_leaderboard.py
+        run: uv run python scripts/render_fev_bench_leaderboard.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.11"
       - name: Install ruff
-        run: pip install ruff
+        run: uv pip install --system ruff
       - name: Check formatting
         run: ruff format --diff src test
       - name: Check imports
@@ -33,11 +33,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.11"
       - name: Install dependencies
-        run: pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu && pip install ".[test]"
+        run: uv pip install --system torch torchvision --index-url https://download.pytorch.org/whl/cpu && uv pip install --system ".[test]"
       - name: Test with pytest
         run: pytest test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
       - name: Install ruff
         run: uv pip install --system ruff
       - name: Check formatting
@@ -33,10 +35,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
       - name: Install dependencies
         run: uv pip install --system torch torchvision --index-url https://download.pytorch.org/whl/cpu && uv pip install --system ".[test]"
       - name: Test with pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
           enable-cache: true
       - name: Install dependencies
         run: |
-          uv venv
           uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
           uv pip install ".[test]"
       - name: Test with pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,31 +17,30 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
-      - name: Install ruff
-        run: uv pip install --system ruff
+        with:
+          python-version: "3.11"
+          enable-cache: true
       - name: Check formatting
-        run: ruff format --diff src test
+        run: uvx ruff format --check --diff src test
       - name: Check imports
-        run: ruff check --select I src test
+        run: uvx ruff check --select I src test
 
   test:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.11"
+          enable-cache: true
       - name: Install dependencies
-        run: uv pip install --system torch torchvision --index-url https://download.pytorch.org/whl/cpu && uv pip install --system ".[test]"
+        run: |
+          uv venv
+          uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+          uv pip install ".[test]"
       - name: Test with pytest
-        run: pytest test
+        run: uv run pytest test


### PR DESCRIPTION
## Summary
- Switch the `lint` and `test` jobs in `ci.yml` from `pip` to a uv-managed setup: `astral-sh/setup-uv@v5` selects Python, lint runs via `uvx ruff` (isolated tool env), and tests run in a `uv venv` via `uv run pytest`. uv caching is enabled.
- Rename the `fev-bench leaderboard preview` workflow to `Leaderboard preview` — the previous check name (`fev-bench leaderboard preview / leaderboard`) was too long.
- The leaderboard job no longer installs the heavy `.[test]` extras. It installs `.` plus `pandas` and `pyyaml` (the two deps the leaderboard script actually needs, declared in its inline script metadata but not part of core `fev` deps), which should make the job faster.

## Notes
- Uses a uv-managed `.venv` + `uv run` rather than installing into the system Python, matching normal project usage.
- Formatting is enforced with `ruff format --check --diff` (fails CI on unformatted code, while still printing the diff).

## Test plan
- CI runs on this PR.