### PR TITLE
Add SECURITY.md and research code notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,3 +144,6 @@ If you find this package useful for your research, please consider citing the as
   primaryClass={cs.LG}
 }
 ```
+
+## Research code
+This repository contains research code intended for academic research and experimentation. It is not production-ready and should be reviewed, tested, and secured before use in production.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+## Reporting Security Issues
+
+Amazon Web Services (AWS) practices industry-standard Coodinated Vulnerability Disclosure (CVD) with the goal of reducing adversary advantage while a security vulnerability is being addressed. The [CERT® Guide to Coordinated Vulnerability Disclosure](https://certcc.github.io/CERT-Guide-to-CVD/tutorials/cvd_in_a_nutshell/) provides information about the CVD process, and outlines tools and practices that can help achieve this goal.
+
+We kindly ask that you **do not** open a public GitHub issue to report security concerns.
+
+Instead, please submit the issue to the AWS Vulnerability Disclosure Program via [HackerOne](https://hackerone.com/aws_vdp) or send your report via [email](mailto:aws-security@amazon.com).
+
+For more details, visit the [AWS Vulnerability Reporting Page](http://aws.amazon.com/security/vulnerability-reporting/).
+
+Thank you in advance for collaborating with us to help protect our customers.


### PR DESCRIPTION
Adds a `SECURITY.md` matching the one in the main [autogluon](https://github.com/autogluon/autogluon) repo, and appends a "Research code" notice to the README indicating this is research code that is not production-ready.