### PR TITLE
tirex-2: cache checkpoint from S3 in wrapper

### DIFF
--- a/models/tirex-2/model.py
+++ b/models/tirex-2/model.py
@@ -32,7 +32,7 @@ class TiRex2Model(fev.ForecastingModel):
     def _load_model(self) -> ForecastModel:
         if self._model is None:
             load_device = "cuda" if self.device.startswith("cuda") else self.device
-            self._model = load_model(self.model_path, device=load_device)
+            self._model = load_model(fev.utils.maybe_cache_from_s3(self.model_path), device=load_device)
             self._model.model.to(self.device)
         return self._model
 


### PR DESCRIPTION
The `tirex-2` wrapper passed `model_path` straight into `load_model`, so an `s3://` prefix would not resolve (unlike the `chronos`/`chronos-2`/`toto-2.0` wrappers, which cache from S3 first).

Wrap it with `fev.utils.maybe_cache_from_s3` so the checkpoint is downloaded locally before loading. Local (`s3://` and hub) paths are unaffected.

Sanity-checked locally: `evaluate.py -m tirex-2 -k '{"model_path":"s3://.../TiRex-2/","device":"cpu"}'` on one task now downloads the checkpoint and produces metrics (exit 0).