### PR TITLE
toto-2.0: load model once across tasks; tirex-2: unpin datasets

### DIFF
--- a/models/tirex-2/requirements.txt
+++ b/models/tirex-2/requirements.txt
@@ -1,4 +1,3 @@
 tirex-2==0.1.0
 fev
-datasets==3.6.0
 pyarrow>=21.0.0

--- a/models/toto-2.0/model.py
+++ b/models/toto-2.0/model.py
@@ -29,6 +29,7 @@ class Toto2Model(fev.ForecastingModel):
         self.decode_block_size = decode_block_size
         self.as_univariate = as_univariate
         self.device = device
+        self._model = None
 
     def _fit_predict(self, task: fev.Task) -> list[datasets.DatasetDict]:
         import torch
@@ -40,7 +41,10 @@ class Toto2Model(fev.ForecastingModel):
 
         target_columns = ["target"] if self.as_univariate else task.target_columns
 
-        model = PretrainedToto2.from_pretrained(fev.utils.maybe_cache_from_s3(self.model_path))
+        if self._model is None:  # load the large model once and reuse it across tasks
+            self._model = PretrainedToto2.from_pretrained(fev.utils.maybe_cache_from_s3(self.model_path))
+            self._model = self._model.to(self.device).eval()
+
         config = Toto2GluonTSModelConfig(
             prediction_length=task.horizon,
             context_length=self.context_length,
@@ -48,7 +52,7 @@ class Toto2Model(fev.ForecastingModel):
             decode_block_size=self.decode_block_size,
             quantiles=task.quantile_levels,
         )
-        gts_model = Toto2GluonTSModel(model.to(self.device).eval(), config)
+        gts_model = Toto2GluonTSModel(self._model, config)
         predictor = gts_model.create_predictor(batch_size=self.batch_size, device=self.device)
 
         logging.getLogger("gluonts").setLevel(100)


### PR DESCRIPTION
Two small model-wrapper fixes surfaced while running multi-task evals.

### `toto-2.0`: load the model once, reuse across tasks
`_fit_predict` is called once per task, and it reloaded the full pretrained model from scratch every time. On GPU the previous task's model was often still resident when the next was moved onto the device, giving a transient **2× model** footprint and `torch.OutOfMemoryError` partway through a multi-task run (observed on a 2.5B checkpoint: process pinned at ~21.5 GiB and failing to allocate tens of MiB, regardless of `batch_size`). Now the model is loaded once (cached on `self._model`) and reused; only the lightweight per-task `config`/predictor is rebuilt.

### `tirex-2`: drop the `datasets==3.6.0` pin
`datasets==3.6.0` can't deserialize parquet whose embedded schema metadata uses the newer `List` feature type (e.g. the TIME-bench datasets), failing with `ValueError: Feature type 'List' not found`. The pin came from `tirex-2`'s `fev` extra; we don't install that extra, so removing the explicit line lets the resolver honor `fev`'s `datasets>=2.15,<5.0` and pick 4.x — matching every other wrapper. Verified on `Commodity_Import/M/short` (resolves to `datasets 4.8.5`, loads and produces metrics).

Both verified locally.