### PR TITLE
Add dataset mirror environment override

### DIFF
--- a/docs/tutorials/05-add-your-model.ipynb
+++ b/docs/tutorials/05-add-your-model.ipynb
@@ -178,57 +178,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Preparing a dataset mirror\n",
+    "### Using a local dataset mirror\n",
     "\n",
-    "Download each dataset configuration once and write it to `<mirror_root>/<dataset_config>/data.parquet`. Pin `revision` to the Hugging Face commit used for your benchmark evaluation. Repeat this for every configuration that you plan to evaluate.\n",
+    "By default, `fev` downloads datasets from Hugging Face Hub. To run evaluation in an isolated environment or avoid repeated Hub downloads, mirror datasets locally and set `FEV_DATASETS_PREFIX`. For each task with a `dataset_config`, `fev` then loads `<FEV_DATASETS_PREFIX>/<dataset_config>/*.parquet`.\n",
     "\n",
-    "For example, this creates a mirror for `ETT_1H` from [`autogluon/fev_datasets`](https://huggingface.co/datasets/autogluon/fev_datasets):\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "For example, download `ETT_1H` from [`autogluon/fev_datasets`](https://huggingface.co/datasets/autogluon/fev_datasets) into a local mirror:\n",
+    "\n",
+    "```python\n",
     "from pathlib import Path\n",
     "\n",
     "import datasets\n",
     "\n",
     "dataset_config = \"ETT_1H\"\n",
-    "mirror_root = Path(\"/mnt/fev-datasets\")\n",
-    "revision = \"main\"  # Replace with a commit SHA for reproducible benchmark evaluation.\n",
-    "dataset = datasets.load_dataset(\n",
-    "    \"autogluon/fev_datasets\",\n",
-    "    name=dataset_config,\n",
-    "    split=\"train\",\n",
-    "    revision=revision,\n",
-    ")\n",
-    "mirror_dir = mirror_root / dataset_config\n",
+    "dataset = datasets.load_dataset(\"autogluon/fev_datasets\", dataset_config, split=\"train\")\n",
+    "mirror_dir = Path(\"/mnt/fev-datasets\") / dataset_config\n",
     "mirror_dir.mkdir(parents=True, exist_ok=True)\n",
-    "dataset.to_parquet(mirror_dir / \"data.parquet\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Using a dataset mirror\n",
+    "dataset.to_parquet(mirror_dir / \"data.parquet\")\n",
+    "```\n",
     "\n",
-    "Set `FEV_DATASETS_PREFIX` to the mirror root. For every task that specifies `dataset_config`, `fev` loads `<FEV_DATASETS_PREFIX>/<dataset_config>/*.parquet` instead of downloading from Hugging Face Hub. The benchmark YAML remains unchanged, so the resulting summaries retain their original dataset metadata.\n",
-    "\n",
-    "For example, with a local mirror containing `/mnt/fev-datasets/ETT_1H/data.parquet`:\n",
+    "Repeat for every dataset configuration that you evaluate, then run the benchmark without changing its YAML:\n",
     "\n",
     "```bash\n",
     "export FEV_DATASETS_PREFIX=/mnt/fev-datasets\n",
-    "export HF_HUB_OFFLINE=1\n",
     "python models/evaluate.py -m my-model\n",
     "```\n",
     "\n",
-    "`HF_HUB_OFFLINE=1` verifies that `fev` does not contact Hugging Face Hub for datasets. It also disables Hub downloads for model weights, so use it only when model artifacts are already cached or available locally. `FEV_DATASETS_PREFIX` can also be an S3 URI, such as `s3://my-bucket/fev-datasets`.\n",
-    "\n",
-    "!!! warning\n",
-    "    You are responsible for ensuring that mirrored parquet files exactly match the dataset revision expected by the benchmark. Otherwise, results may not be comparable even though their summaries retain the original Hugging Face dataset metadata.\n"
+    "For comparable benchmark results, you are responsible for ensuring that the mirrored data exactly matches the expected Hub dataset.\n"
    ]
   },
   {

--- a/docs/tutorials/05-add-your-model.ipynb
+++ b/docs/tutorials/05-add-your-model.ipynb
@@ -178,6 +178,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Using a dataset mirror\n",
+    "\n",
+    "To evaluate the benchmark using locally stored data or an S3 mirror, set `FEV_DATASETS_PREFIX`. For every task that specifies `dataset_config`, `fev` loads `<FEV_DATASETS_PREFIX>/<dataset_config>/*.parquet` instead of downloading from Hugging Face Hub. The benchmark YAML remains unchanged, so the resulting summaries retain their original dataset metadata.\n",
+    "\n",
+    "For example, with a local mirror containing `/mnt/fev-datasets/ETT_1H/data.parquet`:\n",
+    "\n",
+    "```bash\n",
+    "export FEV_DATASETS_PREFIX=/mnt/fev-datasets\n",
+    "python models/evaluate.py -m my-model\n",
+    "```\n",
+    "\n",
+    "`FEV_DATASETS_PREFIX` can also be an S3 URI, such as `s3://my-bucket/fev-datasets`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Running evaluation\n",
     "\n",
     "```bash\n",

--- a/docs/tutorials/05-add-your-model.ipynb
+++ b/docs/tutorials/05-add-your-model.ipynb
@@ -178,18 +178,57 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Preparing a dataset mirror\n",
+    "\n",
+    "Download each dataset configuration once and write it to `<mirror_root>/<dataset_config>/data.parquet`. Pin `revision` to the Hugging Face commit used for your benchmark evaluation. Repeat this for every configuration that you plan to evaluate.\n",
+    "\n",
+    "For example, this creates a mirror for `ETT_1H` from [`autogluon/fev_datasets`](https://huggingface.co/datasets/autogluon/fev_datasets):\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import datasets\n",
+    "\n",
+    "dataset_config = \"ETT_1H\"\n",
+    "mirror_root = Path(\"/mnt/fev-datasets\")\n",
+    "revision = \"main\"  # Replace with a commit SHA for reproducible benchmark evaluation.\n",
+    "dataset = datasets.load_dataset(\n",
+    "    \"autogluon/fev_datasets\",\n",
+    "    name=dataset_config,\n",
+    "    split=\"train\",\n",
+    "    revision=revision,\n",
+    ")\n",
+    "mirror_dir = mirror_root / dataset_config\n",
+    "mirror_dir.mkdir(parents=True, exist_ok=True)\n",
+    "dataset.to_parquet(mirror_dir / \"data.parquet\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Using a dataset mirror\n",
     "\n",
-    "To evaluate the benchmark using locally stored data or an S3 mirror, set `FEV_DATASETS_PREFIX`. For every task that specifies `dataset_config`, `fev` loads `<FEV_DATASETS_PREFIX>/<dataset_config>/*.parquet` instead of downloading from Hugging Face Hub. The benchmark YAML remains unchanged, so the resulting summaries retain their original dataset metadata.\n",
+    "Set `FEV_DATASETS_PREFIX` to the mirror root. For every task that specifies `dataset_config`, `fev` loads `<FEV_DATASETS_PREFIX>/<dataset_config>/*.parquet` instead of downloading from Hugging Face Hub. The benchmark YAML remains unchanged, so the resulting summaries retain their original dataset metadata.\n",
     "\n",
     "For example, with a local mirror containing `/mnt/fev-datasets/ETT_1H/data.parquet`:\n",
     "\n",
     "```bash\n",
     "export FEV_DATASETS_PREFIX=/mnt/fev-datasets\n",
+    "export HF_HUB_OFFLINE=1\n",
     "python models/evaluate.py -m my-model\n",
     "```\n",
     "\n",
-    "`FEV_DATASETS_PREFIX` can also be an S3 URI, such as `s3://my-bucket/fev-datasets`.\n"
+    "`HF_HUB_OFFLINE=1` verifies that `fev` does not contact Hugging Face Hub for datasets. It also disables Hub downloads for model weights, so use it only when model artifacts are already cached or available locally. `FEV_DATASETS_PREFIX` can also be an S3 URI, such as `s3://my-bucket/fev-datasets`.\n",
+    "\n",
+    "!!! warning\n",
+    "    You are responsible for ensuring that mirrored parquet files exactly match the dataset revision expected by the benchmark. Otherwise, results may not be comparable even though their summaries retain the original Hugging Face dataset metadata.\n"
    ]
   },
   {

--- a/src/fev/task.py
+++ b/src/fev/task.py
@@ -2,6 +2,7 @@ import collections
 import copy
 import dataclasses
 import logging
+import os
 import pprint
 import warnings
 from pathlib import Path
@@ -242,8 +243,9 @@ class Task:
         for information on how to load datasets from different sources.
     dataset_config : str | None, default None
         Name of the configuration used when loading datasets from Hugging Face Hub. If `dataset_config` is provided,
-        the datasets will be loaded from HF Hub. If `dataset_config=None`, the dataset will be loaded from a local or
-        S3 path.
+        the datasets will be loaded from HF Hub, unless the `FEV_DATASETS_PREFIX` environment variable is set. In that
+        case, data is loaded from `<FEV_DATASETS_PREFIX>/<dataset_config>/*.parquet`. If `dataset_config=None`, the
+        dataset will be loaded from a local or S3 path.
     horizon : int, default 1
         Length of the forecast horizon (in time steps).
     num_windows : int, default 1
@@ -617,10 +619,17 @@ class Task:
     ) -> datasets.Dataset:
         """Load the raw dataset and apply initial preprocessing based on the Task definition."""
         if self.dataset_config is not None:
-            # Load dataset from HF Hub
-            path = self.dataset_path
-            name = self.dataset_config
-            data_files = None
+            datasets_prefix = os.environ.get("FEV_DATASETS_PREFIX")
+            if datasets_prefix:
+                path = "parquet"
+                name = None
+                data_files = f"{datasets_prefix.rstrip('/')}/{self.dataset_config}/*.parquet"
+                logger.info("Loading dataset %s from mirror %s", self.dataset_config, data_files)
+            else:
+                # Load dataset from HF Hub
+                path = self.dataset_path
+                name = self.dataset_config
+                data_files = None
         else:
             # Load dataset from a local or remote file
             dataset_format = Path(self.dataset_path).suffix.lstrip(".")

--- a/src/fev/task.py
+++ b/src/fev/task.py
@@ -242,10 +242,12 @@ class Task:
         Path to the time series dataset stored locally, on S3, or on Hugging Face Hub. See the Examples section below
         for information on how to load datasets from different sources.
     dataset_config : str | None, default None
-        Name of the configuration used when loading datasets from Hugging Face Hub. If `dataset_config` is provided,
-        the datasets will be loaded from HF Hub, unless the `FEV_DATASETS_PREFIX` environment variable is set. In that
-        case, data is loaded from `<FEV_DATASETS_PREFIX>/<dataset_config>/*.parquet`. If `dataset_config=None`, the
-        dataset will be loaded from a local or S3 path.
+        Name of the dataset configuration. The dataset source is determined as follows:
+
+        - If `dataset_config=None`, data is loaded from `dataset_path`, which can be a local or S3 path.
+        - If `dataset_config` is provided and `FEV_DATASETS_PREFIX` is unset, data is loaded from Hugging Face Hub.
+        - If `dataset_config` is provided and `FEV_DATASETS_PREFIX` is set, data is loaded from
+          `<FEV_DATASETS_PREFIX>/<dataset_config>/*.parquet`.
     horizon : int, default 1
         Length of the forecast horizon (in time steps).
     num_windows : int, default 1

--- a/test/test_task.py
+++ b/test/test_task.py
@@ -354,3 +354,31 @@ def test_when_dataset_is_long_format_parquet_then_task_loads_it(tmp_path):
     assert len(future) == 3
     assert len(past[0]["target"]) == 16
     assert len(future[0]["timestamp"]) == 4
+
+
+def test_when_datasets_prefix_is_set_then_config_dataset_is_loaded_from_mirror(tmp_path, monkeypatch):
+    dataset_config = "test_dataset"
+    mirror_dir = tmp_path / "mirror" / dataset_config
+    mirror_dir.mkdir(parents=True)
+    monkeypatch.setattr(datasets.config, "HF_DATASETS_CACHE", tmp_path / "cache")
+    mirror_dataset = datasets.Dataset.from_dict(
+        {
+            "id": ["series_0"],
+            "timestamp": [[pd.Timestamp("2020-01-01") + pd.Timedelta(days=t) for t in range(4)]],
+            "target": [[float(t) for t in range(4)]],
+        }
+    )
+    mirror_dataset.to_parquet(mirror_dir / "data.parquet")
+    monkeypatch.setenv("FEV_DATASETS_PREFIX", str(tmp_path / "mirror"))
+    monkeypatch.setattr(fev.task.utils, "validate_time_series_dataset", lambda *args, **kwargs: None)
+
+    task = fev.Task(
+        dataset_path="autogluon/fev_datasets",
+        dataset_config=dataset_config,
+        horizon=2,
+    )
+
+    loaded_dataset = task.load_full_dataset(num_proc=1)
+
+    assert len(loaded_dataset) == 1
+    assert loaded_dataset[0]["id"] == "series_0"


### PR DESCRIPTION
## Summary
- add FEV_DATASETS_PREFIX to load configured datasets from a local or S3 parquet mirror
- retain the configured Hugging Face dataset identity in task metadata and summaries
- document the mirror directory layout and cover local mirror loading

## Testing
- .venv/bin/pytest -q test/test_task.py::test_when_datasets_prefix_is_set_then_config_dataset_is_loaded_from_mirror
- .venv/bin/ruff check src/fev/task.py test/test_task.py