### PR TITLE
Add NZQL metric

### DIFF
--- a/src/fev/metrics.py
+++ b/src/fev/metrics.py
@@ -338,7 +338,7 @@ class SMAPE(Metric):
 
 
 class QuantileMetric(Metric):
-    """Base class for quantile loss metrics (MQL, WQL, SQL).
+    """Base class for quantile loss metrics (MQL, WQL, SQL, NQL, NZQL).
 
     Subclasses implement `_per_quantile_level`. The overall score is the mean over quantile levels,
     so `SQL` always equals the mean of `SQL[0.1], SQL[0.5], ...` (single code path, cannot drift).
@@ -461,6 +461,54 @@ class SQL(QuantileMetric):
         )  # [N, D]
         seasonal_error = np.clip(seasonal_error, self.epsilon, None)
         scaled = ql / seasonal_error[:, None, :, None]  # [N, H, D, Q]
+        per_dim = self._safemean(scaled, axis=(0, 1))  # [D, Q]
+        return np.mean(per_dim, axis=0)  # [Q]
+
+
+class NQL(QuantileMetric):
+    """Quantile loss normalized by each item's average historical magnitude.
+
+    Each quantile loss is divided by the mean absolute value of historical observations for its
+    item and target dimension. Items with zero or missing historical magnitude are excluded from
+    aggregation.
+    """
+
+    def __init__(self, epsilon: float = 0.0) -> None:
+        self.epsilon = epsilon
+
+    @staticmethod
+    def _mean_abs_history_per_item(y_past: np.ndarray, y_past_lengths: np.ndarray) -> np.ndarray:
+        """Per-item mean absolute history value. Returns [N, D]; NaN where none exist."""
+        num_series = len(y_past_lengths)
+        num_dims = y_past.shape[1]
+        result = np.full((num_series, num_dims), np.nan, dtype="float64")
+
+        starts = np.concatenate(([0], np.cumsum(y_past_lengths)[:-1]))
+        valid_series = y_past_lengths > 0
+        if not valid_series.any():
+            return result
+
+        valid = ~np.isnan(y_past)
+        sums = np.add.reduceat(np.where(valid, np.abs(y_past), 0.0), starts[valid_series], axis=0)
+        counts = np.add.reduceat(valid.astype(np.int64), starts[valid_series], axis=0)
+        result[valid_series] = np.divide(sums, counts, where=counts > 0, out=np.full_like(sums, np.nan))
+        return result
+
+    def _per_quantile_level(
+        self,
+        *,
+        y_true: np.ndarray,
+        y_pred: np.ndarray,
+        y_past: np.ndarray,
+        y_past_lengths: np.ndarray,
+        q_pred: np.ndarray,
+        seasonality: int,
+        quantile_levels: list[float],
+    ) -> np.ndarray:
+        ql = _quantile_loss(y_true=y_true, q_pred=q_pred, quantile_levels=quantile_levels)  # [N, H, D, Q]
+        scale = self._mean_abs_history_per_item(y_past, y_past_lengths)  # [N, D]
+        scale = np.clip(scale, self.epsilon, None)
+        scaled = ql / scale[:, None, :, None]  # [N, H, D, Q]
         per_dim = self._safemean(scaled, axis=(0, 1))  # [D, Q]
         return np.mean(per_dim, axis=0)  # [Q]
 
@@ -659,5 +707,6 @@ AVAILABLE_METRICS: dict[str, Type[Metric]] = {
     "MQL": MQL,
     "WQL": WQL,
     "SQL": SQL,
+    "NQL": NQL,
     "NZQL": NZQL,
 }

--- a/src/fev/metrics.py
+++ b/src/fev/metrics.py
@@ -465,6 +465,56 @@ class SQL(QuantileMetric):
         return np.mean(per_dim, axis=0)  # [Q]
 
 
+class ADSQL(QuantileMetric):
+    """Average-demand-size scaled quantile loss -- an intermittent-demand variant of SQL.
+
+    Like SQL, but scales each item's quantile loss by its average demand size (the mean of its
+    strictly-positive history).
+
+    Warning:
+        Items with no strictly-positive history have an undefined denominator and are excluded from
+        aggregation, as in SQL.
+    """
+
+    def __init__(self, epsilon: float = 0.0) -> None:
+        self.epsilon = epsilon
+
+    @staticmethod
+    def _mean_positive_history_per_item(y_past: np.ndarray, y_past_lengths: np.ndarray) -> np.ndarray:
+        """Per-item mean of strictly-positive history values. Returns [N, D]; NaN where none exist."""
+        num_series = len(y_past_lengths)
+        num_dims = y_past.shape[1]
+        result = np.full((num_series, num_dims), np.nan, dtype="float64")
+        if num_series == 0:
+            return result
+        segments = np.split(y_past, np.cumsum(y_past_lengths)[:-1], axis=0)
+        for i, segment in enumerate(segments):
+            mask = segment > 0  # strictly positive
+            count = mask.sum(axis=0)  # [D]
+            total = np.where(mask, segment, 0.0).sum(axis=0)  # [D]
+            nonzero = count > 0
+            result[i, nonzero] = total[nonzero] / count[nonzero]
+        return result
+
+    def _per_quantile_level(
+        self,
+        *,
+        y_true: np.ndarray,
+        y_pred: np.ndarray,
+        y_past: np.ndarray,
+        y_past_lengths: np.ndarray,
+        q_pred: np.ndarray,
+        seasonality: int,
+        quantile_levels: list[float],
+    ) -> np.ndarray:
+        ql = _quantile_loss(y_true=y_true, q_pred=q_pred, quantile_levels=quantile_levels)  # [N, H, D, Q]
+        demand_size = self._mean_positive_history_per_item(y_past, y_past_lengths)  # [N, D]
+        demand_size = np.clip(demand_size, self.epsilon, None)  # NaN stays NaN -> item excluded
+        scaled = ql / demand_size[:, None, :, None]  # [N, H, D, Q]
+        per_dim = self._safemean(scaled, axis=(0, 1))  # [D, Q]
+        return np.mean(per_dim, axis=0)  # [Q]
+
+
 class WQL(QuantileMetric):
     """Weighted quantile loss."""
 
@@ -611,4 +661,5 @@ AVAILABLE_METRICS: dict[str, Type[Metric]] = {
     "MQL": MQL,
     "WQL": WQL,
     "SQL": SQL,
+    "ADSQL": ADSQL,
 }

--- a/src/fev/metrics.py
+++ b/src/fev/metrics.py
@@ -465,35 +465,33 @@ class SQL(QuantileMetric):
         return np.mean(per_dim, axis=0)  # [Q]
 
 
-class ADSQL(QuantileMetric):
-    """Average-demand-size scaled quantile loss -- an intermittent-demand variant of SQL.
+class NZQL(QuantileMetric):
+    """Quantile loss normalized by each item's average non-zero historical magnitude.
 
-    Like SQL, but scales each item's quantile loss by its average demand size (the mean of its
-    strictly-positive history).
-
-    Warning:
-        Items with no strictly-positive history have an undefined denominator and are excluded from
-        aggregation, as in SQL.
+    Each quantile loss is divided by the mean absolute value of non-zero historical observations
+    for its item and target dimension. Items with no non-zero historical observations are excluded
+    from aggregation.
     """
 
     def __init__(self, epsilon: float = 0.0) -> None:
         self.epsilon = epsilon
 
     @staticmethod
-    def _mean_positive_history_per_item(y_past: np.ndarray, y_past_lengths: np.ndarray) -> np.ndarray:
-        """Per-item mean of strictly-positive history values. Returns [N, D]; NaN where none exist."""
+    def _mean_nonzero_abs_history_per_item(y_past: np.ndarray, y_past_lengths: np.ndarray) -> np.ndarray:
+        """Per-item mean absolute non-zero history value. Returns [N, D]; NaN where none exist."""
         num_series = len(y_past_lengths)
         num_dims = y_past.shape[1]
         result = np.full((num_series, num_dims), np.nan, dtype="float64")
-        if num_series == 0:
+
+        starts = np.concatenate(([0], np.cumsum(y_past_lengths)[:-1]))
+        valid_series = y_past_lengths > 0
+        if not valid_series.any():
             return result
-        segments = np.split(y_past, np.cumsum(y_past_lengths)[:-1], axis=0)
-        for i, segment in enumerate(segments):
-            mask = segment > 0  # strictly positive
-            count = mask.sum(axis=0)  # [D]
-            total = np.where(mask, segment, 0.0).sum(axis=0)  # [D]
-            nonzero = count > 0
-            result[i, nonzero] = total[nonzero] / count[nonzero]
+
+        nonzero = ~np.isnan(y_past) & (y_past != 0)
+        sums = np.add.reduceat(np.where(nonzero, np.abs(y_past), 0.0), starts[valid_series], axis=0)
+        counts = np.add.reduceat(nonzero.astype(np.int64), starts[valid_series], axis=0)
+        result[valid_series] = np.divide(sums, counts, where=counts > 0, out=np.full_like(sums, np.nan))
         return result
 
     def _per_quantile_level(
@@ -508,9 +506,9 @@ class ADSQL(QuantileMetric):
         quantile_levels: list[float],
     ) -> np.ndarray:
         ql = _quantile_loss(y_true=y_true, q_pred=q_pred, quantile_levels=quantile_levels)  # [N, H, D, Q]
-        demand_size = self._mean_positive_history_per_item(y_past, y_past_lengths)  # [N, D]
-        demand_size = np.clip(demand_size, self.epsilon, None)  # NaN stays NaN -> item excluded
-        scaled = ql / demand_size[:, None, :, None]  # [N, H, D, Q]
+        scale = self._mean_nonzero_abs_history_per_item(y_past, y_past_lengths)  # [N, D]
+        scale = np.clip(scale, self.epsilon, None)
+        scaled = ql / scale[:, None, :, None]  # [N, H, D, Q]
         per_dim = self._safemean(scaled, axis=(0, 1))  # [D, Q]
         return np.mean(per_dim, axis=0)  # [Q]
 
@@ -661,5 +659,5 @@ AVAILABLE_METRICS: dict[str, Type[Metric]] = {
     "MQL": MQL,
     "WQL": WQL,
     "SQL": SQL,
-    "ADSQL": ADSQL,
+    "NZQL": NZQL,
 }

--- a/src/fev/metrics.py
+++ b/src/fev/metrics.py
@@ -338,7 +338,7 @@ class SMAPE(Metric):
 
 
 class QuantileMetric(Metric):
-    """Base class for quantile loss metrics (MQL, WQL, SQL, NQL, NZQL).
+    """Base class for quantile loss metrics (MQL, WQL, SQL, NZQL).
 
     Subclasses implement `_per_quantile_level`. The overall score is the mean over quantile levels,
     so `SQL` always equals the mean of `SQL[0.1], SQL[0.5], ...` (single code path, cannot drift).
@@ -461,54 +461,6 @@ class SQL(QuantileMetric):
         )  # [N, D]
         seasonal_error = np.clip(seasonal_error, self.epsilon, None)
         scaled = ql / seasonal_error[:, None, :, None]  # [N, H, D, Q]
-        per_dim = self._safemean(scaled, axis=(0, 1))  # [D, Q]
-        return np.mean(per_dim, axis=0)  # [Q]
-
-
-class NQL(QuantileMetric):
-    """Quantile loss normalized by each item's average historical magnitude.
-
-    Each quantile loss is divided by the mean absolute value of historical observations for its
-    item and target dimension. Items with zero or missing historical magnitude are excluded from
-    aggregation.
-    """
-
-    def __init__(self, epsilon: float = 0.0) -> None:
-        self.epsilon = epsilon
-
-    @staticmethod
-    def _mean_abs_history_per_item(y_past: np.ndarray, y_past_lengths: np.ndarray) -> np.ndarray:
-        """Per-item mean absolute history value. Returns [N, D]; NaN where none exist."""
-        num_series = len(y_past_lengths)
-        num_dims = y_past.shape[1]
-        result = np.full((num_series, num_dims), np.nan, dtype="float64")
-
-        starts = np.concatenate(([0], np.cumsum(y_past_lengths)[:-1]))
-        valid_series = y_past_lengths > 0
-        if not valid_series.any():
-            return result
-
-        valid = ~np.isnan(y_past)
-        sums = np.add.reduceat(np.where(valid, np.abs(y_past), 0.0), starts[valid_series], axis=0)
-        counts = np.add.reduceat(valid.astype(np.int64), starts[valid_series], axis=0)
-        result[valid_series] = np.divide(sums, counts, where=counts > 0, out=np.full_like(sums, np.nan))
-        return result
-
-    def _per_quantile_level(
-        self,
-        *,
-        y_true: np.ndarray,
-        y_pred: np.ndarray,
-        y_past: np.ndarray,
-        y_past_lengths: np.ndarray,
-        q_pred: np.ndarray,
-        seasonality: int,
-        quantile_levels: list[float],
-    ) -> np.ndarray:
-        ql = _quantile_loss(y_true=y_true, q_pred=q_pred, quantile_levels=quantile_levels)  # [N, H, D, Q]
-        scale = self._mean_abs_history_per_item(y_past, y_past_lengths)  # [N, D]
-        scale = np.clip(scale, self.epsilon, None)
-        scaled = ql / scale[:, None, :, None]  # [N, H, D, Q]
         per_dim = self._safemean(scaled, axis=(0, 1))  # [D, Q]
         return np.mean(per_dim, axis=0)  # [Q]
 
@@ -707,6 +659,5 @@ AVAILABLE_METRICS: dict[str, Type[Metric]] = {
     "MQL": MQL,
     "WQL": WQL,
     "SQL": SQL,
-    "NQL": NQL,
     "NZQL": NZQL,
 }

--- a/src/fev/task.py
+++ b/src/fev/task.py
@@ -885,7 +885,7 @@ class Task:
         extra_info : dict | None
             Optional dictionary with additional information that will be appended to the evaluation summary.
         per_quantile_scores : bool, default False
-            If True, quantile metrics (MQL, WQL, SQL, NQL, NZQL) additionally report a breakdown per quantile level
+            If True, quantile metrics (MQL, WQL, SQL, NZQL) additionally report a breakdown per quantile level
             (e.g. `SQL[0.1]`, `SQL[0.5]`, `SQL[0.9]`) alongside the overall score. Non-quantile metrics
             are unaffected.
 

--- a/src/fev/task.py
+++ b/src/fev/task.py
@@ -885,7 +885,7 @@ class Task:
         extra_info : dict | None
             Optional dictionary with additional information that will be appended to the evaluation summary.
         per_quantile_scores : bool, default False
-            If True, quantile metrics (MQL, WQL, SQL) additionally report a breakdown per quantile level
+            If True, quantile metrics (MQL, WQL, SQL, NQL, NZQL) additionally report a breakdown per quantile level
             (e.g. `SQL[0.1]`, `SQL[0.5]`, `SQL[0.9]`) alongside the overall score. Non-quantile metrics
             are unaffected.
 

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -44,7 +44,8 @@ def _fev_predictions(predictor, train_df):
     return [pred.to_dict("list") for _, pred in ag_predictions.groupby("item_id", as_index=False)]
 
 
-@pytest.mark.parametrize("eval_metric", list(AVAILABLE_METRICS))
+# ADSQL has no AutoGluon counterpart; it is checked separately in test_adsql_matches_reference.
+@pytest.mark.parametrize("eval_metric", [m for m in AVAILABLE_METRICS if m != "ADSQL"])
 def test_when_metrics_computed_then_score_matches_autogluon(model_setup, eval_metric):
     task, train_df, test_df, predictor = model_setup
     task.eval_metric = eval_metric
@@ -113,7 +114,45 @@ def test_seasonal_error_per_item_empty():
     assert result.dtype == np.float64
 
 
-@pytest.mark.parametrize("metric_name", ["MQL", "WQL", "SQL"])
+def _adsql(y_true, q_pred, y_past, y_past_lengths, quantile_levels):
+    """Convenience wrapper: compute ADSQL from explicit arrays (seasonality is unused by ADSQL)."""
+    return fev.metrics.ADSQL().compute(
+        y_true=y_true,
+        y_pred=q_pred[..., 0],
+        y_past=y_past,
+        y_past_lengths=y_past_lengths,
+        q_pred=q_pred,
+        seasonality=1,
+        quantile_levels=quantile_levels,
+    )
+
+
+def test_adsql_matches_reference():
+    """Median-only ADSQL against a hand-computed reference, including a zero-history exclusion."""
+    # Two items, horizon 2. Item 0 history mean-positive = (1+3)/2 = 2; item 1 = (2+4)/2 = 3.
+    y_past = np.array([[0.0], [1.0], [3.0], [2.0], [0.0], [4.0]])  # concatenated, [total_T, D]
+    y_past_lengths = np.array([3, 3])
+    y_true = np.array([[[2.0], [0.0]], [[0.0], [6.0]]])  # [N, H, D]
+    q_pred = np.array([[[[1.0]], [[0.0]]], [[[0.0]], [[3.0]]]])  # [N, H, D, Q=1] at q=0.5
+
+    got = _adsql(y_true, q_pred, y_past, y_past_lengths, [0.5])
+    # pinball loss at q=0.5 is |y - q|; scaled by demand size, then meaned over all (item, step).
+    expected = float(np.mean([1 / 2.0, 0.0, 0.0, 3 / 3.0]))
+    assert np.isclose(got, expected)
+
+
+def test_adsql_excludes_zero_history_item():
+    """An item whose entire history is zero has an undefined denominator and is dropped."""
+    y_past = np.array([[0.0], [0.0], [5.0], [5.0]])  # item0 all-zero history, item1 mean-positive = 5
+    y_past_lengths = np.array([2, 2])
+    y_true = np.array([[[1.0]], [[1.0]]])  # [N, H=1, D]
+    q_pred = np.array([[[[0.0]]], [[[0.0]]]])  # only item1 counts: |1-0|/5 = 0.2
+
+    got = _adsql(y_true, q_pred, y_past, y_past_lengths, [0.5])
+    assert np.isclose(got, 0.2)
+
+
+@pytest.mark.parametrize("metric_name", ["MQL", "WQL", "SQL", "ADSQL"])
 def test_when_per_quantile_scores_then_overall_equals_mean_of_per_level(model_setup, metric_name):
     task, train_df, _, predictor = model_setup
     task.eval_metric = metric_name
@@ -124,7 +163,7 @@ def test_when_per_quantile_scores_then_overall_equals_mean_of_per_level(model_se
     assert np.isclose(summary[metric_name], np.mean(per_level))
 
 
-@pytest.mark.parametrize("metric_name", ["MQL", "WQL", "SQL"])
+@pytest.mark.parametrize("metric_name", ["MQL", "WQL", "SQL", "ADSQL"])
 def test_when_per_quantile_scores_disabled_then_no_per_level_keys(model_setup, metric_name):
     task, train_df, _, predictor = model_setup
     task.eval_metric = metric_name

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -44,8 +44,8 @@ def _fev_predictions(predictor, train_df):
     return [pred.to_dict("list") for _, pred in ag_predictions.groupby("item_id", as_index=False)]
 
 
-# ADSQL has no AutoGluon counterpart; it is checked separately in test_adsql_matches_reference.
-@pytest.mark.parametrize("eval_metric", [m for m in AVAILABLE_METRICS if m != "ADSQL"])
+# NZQL has no AutoGluon counterpart; it is checked separately in test_nzql_matches_reference.
+@pytest.mark.parametrize("eval_metric", [m for m in AVAILABLE_METRICS if m != "NZQL"])
 def test_when_metrics_computed_then_score_matches_autogluon(model_setup, eval_metric):
     task, train_df, test_df, predictor = model_setup
     task.eval_metric = eval_metric
@@ -114,9 +114,9 @@ def test_seasonal_error_per_item_empty():
     assert result.dtype == np.float64
 
 
-def _adsql(y_true, q_pred, y_past, y_past_lengths, quantile_levels):
-    """Convenience wrapper: compute ADSQL from explicit arrays (seasonality is unused by ADSQL)."""
-    return fev.metrics.ADSQL().compute(
+def _nzql(y_true, q_pred, y_past, y_past_lengths, quantile_levels):
+    """Convenience wrapper: compute NZQL from explicit arrays (seasonality is unused by NZQL)."""
+    return fev.metrics.NZQL().compute(
         y_true=y_true,
         y_pred=q_pred[..., 0],
         y_past=y_past,
@@ -127,32 +127,52 @@ def _adsql(y_true, q_pred, y_past, y_past_lengths, quantile_levels):
     )
 
 
-def test_adsql_matches_reference():
-    """Median-only ADSQL against a hand-computed reference, including a zero-history exclusion."""
-    # Two items, horizon 2. Item 0 history mean-positive = (1+3)/2 = 2; item 1 = (2+4)/2 = 3.
+def test_nzql_matches_reference():
+    """Median-only NZQL against a hand-computed reference, including a zero-history exclusion."""
+    # Two items, horizon 2. Item 0 mean non-zero abs history = (1+3)/2 = 2; item 1 = (2+4)/2 = 3.
     y_past = np.array([[0.0], [1.0], [3.0], [2.0], [0.0], [4.0]])  # concatenated, [total_T, D]
     y_past_lengths = np.array([3, 3])
     y_true = np.array([[[2.0], [0.0]], [[0.0], [6.0]]])  # [N, H, D]
     q_pred = np.array([[[[1.0]], [[0.0]]], [[[0.0]], [[3.0]]]])  # [N, H, D, Q=1] at q=0.5
 
-    got = _adsql(y_true, q_pred, y_past, y_past_lengths, [0.5])
+    got = _nzql(y_true, q_pred, y_past, y_past_lengths, [0.5])
     # pinball loss at q=0.5 is |y - q|; scaled by demand size, then meaned over all (item, step).
     expected = float(np.mean([1 / 2.0, 0.0, 0.0, 3 / 3.0]))
     assert np.isclose(got, expected)
 
 
-def test_adsql_excludes_zero_history_item():
+def test_nzql_excludes_zero_history_item():
     """An item whose entire history is zero has an undefined denominator and is dropped."""
-    y_past = np.array([[0.0], [0.0], [5.0], [5.0]])  # item0 all-zero history, item1 mean-positive = 5
+    y_past = np.array([[0.0], [0.0], [5.0], [5.0]])  # item0 all-zero history, item1 mean non-zero abs = 5
     y_past_lengths = np.array([2, 2])
     y_true = np.array([[[1.0]], [[1.0]]])  # [N, H=1, D]
     q_pred = np.array([[[[0.0]]], [[[0.0]]]])  # only item1 counts: |1-0|/5 = 0.2
 
-    got = _adsql(y_true, q_pred, y_past, y_past_lengths, [0.5])
+    got = _nzql(y_true, q_pred, y_past, y_past_lengths, [0.5])
     assert np.isclose(got, 0.2)
 
 
-@pytest.mark.parametrize("metric_name", ["MQL", "WQL", "SQL", "ADSQL"])
+def test_nzql_mean_nonzero_abs_history_per_item():
+    """Average demand size is computed independently for ragged multi-dimensional histories."""
+    y_past = np.array(
+        [
+            [0.0, np.nan],
+            [1.0, -2.0],
+            [3.0, 4.0],
+            [0.0, 0.0],
+            [np.nan, 5.0],
+            [-1.0, 7.0],
+        ]
+    )
+    y_past_lengths = np.array([3, 0, 3])
+
+    result = fev.metrics.NZQL._mean_nonzero_abs_history_per_item(y_past, y_past_lengths)
+
+    expected = np.array([[2.0, 3.0], [np.nan, np.nan], [1.0, 6.0]])
+    np.testing.assert_allclose(result, expected)
+
+
+@pytest.mark.parametrize("metric_name", ["MQL", "WQL", "SQL", "NZQL"])
 def test_when_per_quantile_scores_then_overall_equals_mean_of_per_level(model_setup, metric_name):
     task, train_df, _, predictor = model_setup
     task.eval_metric = metric_name
@@ -163,7 +183,7 @@ def test_when_per_quantile_scores_then_overall_equals_mean_of_per_level(model_se
     assert np.isclose(summary[metric_name], np.mean(per_level))
 
 
-@pytest.mark.parametrize("metric_name", ["MQL", "WQL", "SQL", "ADSQL"])
+@pytest.mark.parametrize("metric_name", ["MQL", "WQL", "SQL", "NZQL"])
 def test_when_per_quantile_scores_disabled_then_no_per_level_keys(model_setup, metric_name):
     task, train_df, _, predictor = model_setup
     task.eval_metric = metric_name

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -44,8 +44,8 @@ def _fev_predictions(predictor, train_df):
     return [pred.to_dict("list") for _, pred in ag_predictions.groupby("item_id", as_index=False)]
 
 
-# NZQL has no AutoGluon counterpart; it is checked separately in test_nzql_matches_reference.
-@pytest.mark.parametrize("eval_metric", [m for m in AVAILABLE_METRICS if m != "NZQL"])
+# NQL and NZQL have no AutoGluon counterparts; they are checked against hand-computed references.
+@pytest.mark.parametrize("eval_metric", [m for m in AVAILABLE_METRICS if m not in {"NQL", "NZQL"}])
 def test_when_metrics_computed_then_score_matches_autogluon(model_setup, eval_metric):
     task, train_df, test_df, predictor = model_setup
     task.eval_metric = eval_metric
@@ -127,6 +127,32 @@ def _nzql(y_true, q_pred, y_past, y_past_lengths, quantile_levels):
     )
 
 
+def _nql(y_true, q_pred, y_past, y_past_lengths, quantile_levels):
+    """Convenience wrapper: compute NQL from explicit arrays (seasonality is unused by NQL)."""
+    return fev.metrics.NQL().compute(
+        y_true=y_true,
+        y_pred=q_pred[..., 0],
+        y_past=y_past,
+        y_past_lengths=y_past_lengths,
+        q_pred=q_pred,
+        seasonality=1,
+        quantile_levels=quantile_levels,
+    )
+
+
+def test_nql_matches_reference():
+    """Median-only NQL against a hand-computed reference."""
+    # Mean absolute history is (0+1+3)/3 = 4/3 for item 0 and (2+0+4)/3 = 2 for item 1.
+    y_past = np.array([[0.0], [1.0], [3.0], [2.0], [0.0], [4.0]])
+    y_past_lengths = np.array([3, 3])
+    y_true = np.array([[[2.0], [0.0]], [[0.0], [6.0]]])
+    q_pred = np.array([[[[1.0]], [[0.0]]], [[[0.0]], [[3.0]]]])
+
+    got = _nql(y_true, q_pred, y_past, y_past_lengths, [0.5])
+    expected = float(np.mean([1 / (4 / 3), 0.0, 0.0, 3 / 2.0]))
+    assert np.isclose(got, expected)
+
+
 def test_nzql_matches_reference():
     """Median-only NZQL against a hand-computed reference, including a zero-history exclusion."""
     # Two items, horizon 2. Item 0 mean non-zero abs history = (1+3)/2 = 2; item 1 = (2+4)/2 = 3.
@@ -136,7 +162,7 @@ def test_nzql_matches_reference():
     q_pred = np.array([[[[1.0]], [[0.0]]], [[[0.0]], [[3.0]]]])  # [N, H, D, Q=1] at q=0.5
 
     got = _nzql(y_true, q_pred, y_past, y_past_lengths, [0.5])
-    # pinball loss at q=0.5 is |y - q|; scaled by demand size, then meaned over all (item, step).
+    # Pinball loss at q=0.5 is |y - q|; normalize by each item's non-zero historical magnitude.
     expected = float(np.mean([1 / 2.0, 0.0, 0.0, 3 / 3.0]))
     assert np.isclose(got, expected)
 
@@ -152,8 +178,8 @@ def test_nzql_excludes_zero_history_item():
     assert np.isclose(got, 0.2)
 
 
-def test_nzql_mean_nonzero_abs_history_per_item():
-    """Average demand size is computed independently for ragged multi-dimensional histories."""
+def test_nql_and_nzql_history_scales():
+    """Historical scales are computed independently for ragged multi-dimensional histories."""
     y_past = np.array(
         [
             [0.0, np.nan],
@@ -166,13 +192,14 @@ def test_nzql_mean_nonzero_abs_history_per_item():
     )
     y_past_lengths = np.array([3, 0, 3])
 
-    result = fev.metrics.NZQL._mean_nonzero_abs_history_per_item(y_past, y_past_lengths)
+    nql_scale = fev.metrics.NQL._mean_abs_history_per_item(y_past, y_past_lengths)
+    nzql_scale = fev.metrics.NZQL._mean_nonzero_abs_history_per_item(y_past, y_past_lengths)
 
-    expected = np.array([[2.0, 3.0], [np.nan, np.nan], [1.0, 6.0]])
-    np.testing.assert_allclose(result, expected)
+    np.testing.assert_allclose(nql_scale, [[4 / 3, 3.0], [np.nan, np.nan], [0.5, 4.0]])
+    np.testing.assert_allclose(nzql_scale, [[2.0, 3.0], [np.nan, np.nan], [1.0, 6.0]])
 
 
-@pytest.mark.parametrize("metric_name", ["MQL", "WQL", "SQL", "NZQL"])
+@pytest.mark.parametrize("metric_name", ["MQL", "WQL", "SQL", "NQL", "NZQL"])
 def test_when_per_quantile_scores_then_overall_equals_mean_of_per_level(model_setup, metric_name):
     task, train_df, _, predictor = model_setup
     task.eval_metric = metric_name
@@ -183,7 +210,7 @@ def test_when_per_quantile_scores_then_overall_equals_mean_of_per_level(model_se
     assert np.isclose(summary[metric_name], np.mean(per_level))
 
 
-@pytest.mark.parametrize("metric_name", ["MQL", "WQL", "SQL", "NZQL"])
+@pytest.mark.parametrize("metric_name", ["MQL", "WQL", "SQL", "NQL", "NZQL"])
 def test_when_per_quantile_scores_disabled_then_no_per_level_keys(model_setup, metric_name):
     task, train_df, _, predictor = model_setup
     task.eval_metric = metric_name

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -44,8 +44,8 @@ def _fev_predictions(predictor, train_df):
     return [pred.to_dict("list") for _, pred in ag_predictions.groupby("item_id", as_index=False)]
 
 
-# NQL and NZQL have no AutoGluon counterparts; they are checked against hand-computed references.
-@pytest.mark.parametrize("eval_metric", [m for m in AVAILABLE_METRICS if m not in {"NQL", "NZQL"}])
+# NZQL has no AutoGluon counterpart; it is checked against a hand-computed reference.
+@pytest.mark.parametrize("eval_metric", [m for m in AVAILABLE_METRICS if m != "NZQL"])
 def test_when_metrics_computed_then_score_matches_autogluon(model_setup, eval_metric):
     task, train_df, test_df, predictor = model_setup
     task.eval_metric = eval_metric
@@ -127,32 +127,6 @@ def _nzql(y_true, q_pred, y_past, y_past_lengths, quantile_levels):
     )
 
 
-def _nql(y_true, q_pred, y_past, y_past_lengths, quantile_levels):
-    """Convenience wrapper: compute NQL from explicit arrays (seasonality is unused by NQL)."""
-    return fev.metrics.NQL().compute(
-        y_true=y_true,
-        y_pred=q_pred[..., 0],
-        y_past=y_past,
-        y_past_lengths=y_past_lengths,
-        q_pred=q_pred,
-        seasonality=1,
-        quantile_levels=quantile_levels,
-    )
-
-
-def test_nql_matches_reference():
-    """Median-only NQL against a hand-computed reference."""
-    # Mean absolute history is (0+1+3)/3 = 4/3 for item 0 and (2+0+4)/3 = 2 for item 1.
-    y_past = np.array([[0.0], [1.0], [3.0], [2.0], [0.0], [4.0]])
-    y_past_lengths = np.array([3, 3])
-    y_true = np.array([[[2.0], [0.0]], [[0.0], [6.0]]])
-    q_pred = np.array([[[[1.0]], [[0.0]]], [[[0.0]], [[3.0]]]])
-
-    got = _nql(y_true, q_pred, y_past, y_past_lengths, [0.5])
-    expected = float(np.mean([1 / (4 / 3), 0.0, 0.0, 3 / 2.0]))
-    assert np.isclose(got, expected)
-
-
 def test_nzql_matches_reference():
     """Median-only NZQL against a hand-computed reference, including a zero-history exclusion."""
     # Two items, horizon 2. Item 0 mean non-zero abs history = (1+3)/2 = 2; item 1 = (2+4)/2 = 3.
@@ -178,8 +152,8 @@ def test_nzql_excludes_zero_history_item():
     assert np.isclose(got, 0.2)
 
 
-def test_nql_and_nzql_history_scales():
-    """Historical scales are computed independently for ragged multi-dimensional histories."""
+def test_nzql_history_scale():
+    """The historical scale is computed independently for ragged multi-dimensional histories."""
     y_past = np.array(
         [
             [0.0, np.nan],
@@ -192,14 +166,12 @@ def test_nql_and_nzql_history_scales():
     )
     y_past_lengths = np.array([3, 0, 3])
 
-    nql_scale = fev.metrics.NQL._mean_abs_history_per_item(y_past, y_past_lengths)
     nzql_scale = fev.metrics.NZQL._mean_nonzero_abs_history_per_item(y_past, y_past_lengths)
 
-    np.testing.assert_allclose(nql_scale, [[4 / 3, 3.0], [np.nan, np.nan], [0.5, 4.0]])
     np.testing.assert_allclose(nzql_scale, [[2.0, 3.0], [np.nan, np.nan], [1.0, 6.0]])
 
 
-@pytest.mark.parametrize("metric_name", ["MQL", "WQL", "SQL", "NQL", "NZQL"])
+@pytest.mark.parametrize("metric_name", ["MQL", "WQL", "SQL", "NZQL"])
 def test_when_per_quantile_scores_then_overall_equals_mean_of_per_level(model_setup, metric_name):
     task, train_df, _, predictor = model_setup
     task.eval_metric = metric_name
@@ -210,7 +182,7 @@ def test_when_per_quantile_scores_then_overall_equals_mean_of_per_level(model_se
     assert np.isclose(summary[metric_name], np.mean(per_level))
 
 
-@pytest.mark.parametrize("metric_name", ["MQL", "WQL", "SQL", "NQL", "NZQL"])
+@pytest.mark.parametrize("metric_name", ["MQL", "WQL", "SQL", "NZQL"])
 def test_when_per_quantile_scores_disabled_then_no_per_level_keys(model_setup, metric_name):
     task, train_df, _, predictor = model_setup
     task.eval_metric = metric_name


### PR DESCRIPTION
## Summary

- Add NZQL, which normalizes quantile loss by the mean absolute value of each item and target dimension's non-zero historical observations.
- Register NZQL and add unit coverage for its scale and quantile-score reporting.

## Validation

- Targeted NZQL registry check
- Focused lint and formatting checks

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.